### PR TITLE
Changed serialize/deserialize functions into functors to allow for pa…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ option(COROKAFKA_BOOST_USE_MULTITHREADED "Use Boost multithreaded libraries." ON
 option(COROKAFKA_BOOST_USE_VALGRIND "Use valgrind headers for Boost." OFF)
 option(COROKAFKA_EXPORT_PKGCONFIG "Generate 'quantum.pc' file" ON)
 option(COROKAFKA_EXPORT_CMAKE_CONFIG "Generate CMake config, target and version files." ON)
-option(COROKAFKA_DECLARE_SERIALIZABLE_CONCEPT "Allow declaration of serializers and deserializers after corokafka.h." OFF)
 
 if (COROKAFKA_INSTALL_ROOT)
     set(CMAKE_INSTALL_PREFIX ${COROKAFKA_INSTALL_ROOT})
@@ -107,10 +106,6 @@ add_definitions(
     -D_POSIX_PTHREAD_SEMANTICS
     -D__FUNCTION__=__FILE__
 )
-
-if (COROKAFKA_DECLARE_SERIALIZABLE_CONCEPT)
-    add_definitions(-D__COROKAFKA_DECLARE_SERIALIZABLE_CONCEPT)
-endif()
 
 if(COROKAFKA_BUILD_SHARED)
     message(STATUS "Build will generate a shared library. "

--- a/corokafka/corokafka_deserializer.h
+++ b/corokafka/corokafka_deserializer.h
@@ -63,7 +63,7 @@ public:
     
     ResultType operator()(const cppkafka::TopicPartition& toppar,
                           const cppkafka::Buffer& buffer) const final {
-        return deserialize(toppar, buffer, (T*)0);
+        return Deserialize<T>{}(toppar, buffer);
     }
 };
 


### PR DESCRIPTION
Changed serialize/deserialize functions into functors to allow for partial specializations as well.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
Serializing and de-serializing types is now implemented via functors. Instead of:
```c++
template <typename T>
std::vector<uint8_t> serialize(const T&);
template <typename T>
T deserialize(const cppkafka::TopicPartition&, const cppkafka::Buffer&, T*);
```
it is now:
```c++
template <typename T>
struct Serialize
{
    std::vector<uint8_t> operator()(const T&);
};
template <typename T>
struct Deserialize
{
    T operator()(const cppkafka::TopicPartition&, const cppkafka::Buffer&);
};
```
This change also allows to get rid of the trailing parameter in the de-serialize functions which was only used for ADL.

**Testing performed**
Compiled
