### PR TITLE
Fixed batch count when messages are less than the number of coroutines

### DIFF
--- a/corokafka/corokafka_consumer_configuration.cpp
+++ b/corokafka/corokafka_consumer_configuration.cpp
@@ -117,6 +117,9 @@ const TypeErasedDeserializer& ConsumerConfiguration::getTypeErasedDeserializer()
 
 const Receiver& ConsumerConfiguration::getTypeErasedReceiver() const
 {
+    if (!_receiver) {
+        throw std::runtime_error(std::string("Receiver callback not set for topic ") + getTopic());
+    }
     return *_receiver;
 }
 

--- a/corokafka/impl/corokafka_consumer_configuration_impl.h
+++ b/corokafka/impl/corokafka_consumer_configuration_impl.h
@@ -35,7 +35,7 @@ void ConsumerConfiguration::setReceiverCallback(const TOPIC& topic, Callbacks::R
 {
     static_assert(TOPIC::isSerializable(), "Topic contains types which are not serializable");
     if (_receiver) {
-        throw std::runtime_error("Receiver already set");
+        throw std::runtime_error(std::string("Receiver already set for topic " + getTopic()));
     }
     _typeErasedDeserializer = {topic};
     _receiver.reset(new ConcreteReceiver<TOPIC>(std::move(receiver)));

--- a/corokafka/impl/corokafka_consumer_manager_impl.cpp
+++ b/corokafka/impl/corokafka_consumer_manager_impl.cpp
@@ -78,6 +78,9 @@ void ConsumerManagerImpl::setup(const std::string& topic, ConsumerTopicEntry& to
         throw std::runtime_error(std::string("Consumer broker list not found. Please set 'metadata.broker.list' for topic ") + topic);
     }
     
+    //Check if the receiver is set (will throw if not set)
+    topicEntry._configuration.getTypeErasedReceiver();
+    
     //Set the rdkafka configuration options
     cppkafka::Configuration kafkaConfig(rdKafkaOptions);
     kafkaConfig.set_default_topic_configuration(cppkafka::TopicConfiguration(rdKafkaTopicOptions));
@@ -1045,9 +1048,9 @@ ConsumerManagerImpl::deserializeBatchCoro(quantum::VoidContextPtr ctx,
     size_t batchIndex = 0;
     
     // Post unto all the coroutine threads.
-    for (int i = entry._coroQueueIdRangeForAny.first; i <= entry._coroQueueIdRangeForAny.second; ++i) {
+    for (int h = 0, i = entry._coroQueueIdRangeForAny.first; i <= entry._coroQueueIdRangeForAny.second; ++i, ++h) {
         //get the begin and end iterators for each batch
-        size_t batchSize = (i < remainder) ? numPerBatch + 1 : numPerBatch;
+        size_t batchSize = (h < remainder) ? numPerBatch + 1 : numPerBatch;
         if (batchSize == 0) {
             break; //nothing to do
         }


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
- Fixed batch count when messages are less than the number of coroutines. This caused certain messages not to be processed properly. 
- Validate receiver callback for consumers. 

**Testing performed**
- Tested with a small batch of messages (< number of coroutines). 
