### PR TITLE
Fix offset commit value when offset range is > 1

### DIFF
--- a/corokafka/corokafka_consumer_manager.h
+++ b/corokafka/corokafka_consumer_manager.h
@@ -82,8 +82,8 @@ public:
      *          should be made via the ReceivedMessage::commit() API.
      */
     cppkafka::Error commit(const cppkafka::TopicPartition& topicPartition,
-                 const void* opaque = nullptr,
-                 bool forceSync = false);
+                           const void* opaque = nullptr,
+                           bool forceSync = false);
     
     /**
      * @brief Similar to the above commit() but supporting a list of partitions.
@@ -94,8 +94,8 @@ public:
      * @return Error object. If the number of retries reach 0, error contains RD_KAFKA_RESP_ERR__FAIL.
      */
     cppkafka::Error commit(const cppkafka::TopicPartitionList& topicPartitions,
-                 const void* opaque = nullptr,
-                 bool forceSync = false);
+                           const void* opaque = nullptr,
+                           bool forceSync = false);
     
     /**
      * @brief Gracefully shut down all consumers and unsubscribe from all topics.

--- a/corokafka/impl/corokafka_consumer_manager_impl.cpp
+++ b/corokafka/impl/corokafka_consumer_manager_impl.cpp
@@ -704,14 +704,11 @@ void ConsumerManagerImpl::offsetCommitCallback(
                         const cppkafka::TopicPartitionList& topicPartitions)
 {
     // Check if we have opaque data
-    cppkafka::TopicPartitionList& partitions = const_cast<cppkafka::TopicPartitionList&>(topicPartitions);
     std::vector<const void*> opaques;
     if (!topicEntry._offsets.empty()) {
-        opaques.reserve(partitions.size());
+        opaques.reserve(topicPartitions.size());
     }
-    for (auto& partition : partitions) {
-        //subtract one since rdkafka always gives us the next offset
-        partition.set_offset(partition.get_offset()-1);
+    for (auto& partition : topicPartitions) {
         //remove the opaque values and pass them back to the application
         if (!topicEntry._offsets.empty()) {
             opaques.push_back(topicEntry._offsets.remove(partition));
@@ -719,7 +716,7 @@ void ConsumerManagerImpl::offsetCommitCallback(
     }
     cppkafka::CallbackInvoker<Callbacks::OffsetCommitCallback>
         ("offset commit", topicEntry._configuration.getOffsetCommitCallback(), &consumer)
-            (makeMetadata(topicEntry), error, partitions, opaques);
+            (makeMetadata(topicEntry), error, topicPartitions, opaques);
 }
 
 bool ConsumerManagerImpl::offsetCommitErrorCallback(

--- a/corokafka/utils/corokafka_offset_manager.cpp
+++ b/corokafka/utils/corokafka_offset_manager.cpp
@@ -52,7 +52,14 @@ cppkafka::Error OffsetManager::saveOffset(const cppkafka::TopicPartition& offset
         Range<int64_t> range = insertOffset(ranges, offset.get_offset());
         //Commit range
         if (range.second != -1) {
-            return commit(offset, ranges._syncCommit || forceSync);
+            if (offset.get_offset() == range.second) {
+                return commit(offset, ranges._syncCommit || forceSync);
+            }
+            else {
+                //End of the range is greater than the committed offset
+                return commit(cppkafka::TopicPartition{offset.get_topic(), offset.get_partition(), range.second},
+                              ranges._syncCommit || forceSync);
+            }
         }
         return {};
     }


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
* When committing an offset range using the offset manager, if the range contained more than one offset, only the first offset in the range was committed instead of the last. 
* Do not decrement by 1 in the offset commit callback.

**Testing performed**
Committed a group of messages from the same partition.
