### PR TITLE
Move partition assignment configuration to the topic section.

### DIFF
--- a/corokafka/corokafka_configuration.cpp
+++ b/corokafka/corokafka_configuration.cpp
@@ -89,6 +89,25 @@ const std::string& Configuration::getJsonSchema()
                 "additionalProperties": false,
                 "required": []
             },
+            "partitionConfig": {
+                "title": "Partition assignment configuration for a topic.",
+                "type": "object",
+                "properties": {
+                    "strategy": {
+                        "description":"Only applies to consumer topic configurations",
+                        "type":"string",
+                        "enum":["static","dynamic"],
+                        "default":"dynamic"
+                    },
+                    "partitions": {
+                        "description":"Only applies to consumer topic configurations",
+                        "type":"array",
+                        "items": { "$ref" : "#/definitions/partition" }
+                    }
+                },
+                "additionalProperties": false,
+                "required": []
+            },
             "topicConfig": {
                 "title": "Consumer or producer topic configuration",
                 "type": "object",
@@ -108,17 +127,6 @@ const std::string& Configuration::getJsonSchema()
                     "topicOptions": {
                         "description": "The rdkafka and corokafka topic options for this consumer/producer",
                         "$ref" : "#/definitions/option"
-                    },
-                    "partitionStrategy": {
-                        "description":"Only applies to consumer topic configurations",
-                        "type":"string",
-                        "enum":["static","dynamic"],
-                        "default":"dynamic"
-                    },
-                    "partitionAssignment": {
-                        "description":"Only applies to consumer topic configurations",
-                        "type":"array",
-                        "items": { "$ref" : "#/definitions/partition" }
                     }
                 },
                 "additionalProperties": false,
@@ -135,6 +143,10 @@ const std::string& Configuration::getJsonSchema()
                     "config": {
                         "description": "The config for this topic",
                         "type":"string"
+                    },
+                    "assignment": {
+                        "description": "The partition strategy and assignment (consumers only)",
+                        "$ref" : "#/definitions/partitionConfig"
                     }
                 },
                 "additionalProperties": false,


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
Move the partition strategy/assignment from the generic consumer configuration object into the topic object. This allows complete segregation of topic assignment and manipulation of offsets on a per topic basis rather than being shared across multiple consumers via a common configuration. This is especially useful while testing a specific topic or trying to isolate a specific partition/offsets while maintaining all other topic runtime behaviors the same.

Note that if the `assignment` property is supplied for a producer topic, it should have no effect.

**Testing performed**
Parsed configuration and made sure consumers work as intended.
