### PR TITLE
Make pause/resume atomic

### DIFF
--- a/corokafka/corokafka_configuration.cpp
+++ b/corokafka/corokafka_configuration.cpp
@@ -89,6 +89,25 @@ const std::string& Configuration::getJsonSchema()
                 "additionalProperties": false,
                 "required": []
             },
+            "partitionConfig": {
+                "title": "Partition assignment configuration for a topic.",
+                "type": "object",
+                "properties": {
+                    "strategy": {
+                        "description":"Only applies to consumer topic configurations",
+                        "type":"string",
+                        "enum":["static","dynamic"],
+                        "default":"dynamic"
+                    },
+                    "partitions": {
+                        "description":"Only applies to consumer topic configurations",
+                        "type":"array",
+                        "items": { "$ref" : "#/definitions/partition" }
+                    }
+                },
+                "additionalProperties": false,
+                "required": []
+            },
             "topicConfig": {
                 "title": "Consumer or producer topic configuration",
                 "type": "object",
@@ -108,17 +127,6 @@ const std::string& Configuration::getJsonSchema()
                     "topicOptions": {
                         "description": "The rdkafka and corokafka topic options for this consumer/producer",
                         "$ref" : "#/definitions/option"
-                    },
-                    "partitionStrategy": {
-                        "description":"Only applies to consumer topic configurations",
-                        "type":"string",
-                        "enum":["static","dynamic"],
-                        "default":"dynamic"
-                    },
-                    "partitionAssignment": {
-                        "description":"Only applies to consumer topic configurations",
-                        "type":"array",
-                        "items": { "$ref" : "#/definitions/partition" }
                     }
                 },
                 "additionalProperties": false,
@@ -135,6 +143,10 @@ const std::string& Configuration::getJsonSchema()
                     "config": {
                         "description": "The config for this topic",
                         "type":"string"
+                    },
+                    "assignment": {
+                        "description": "The partition strategy and assignment (consumers only)",
+                        "$ref" : "#/definitions/partitionConfig"
                     }
                 },
                 "additionalProperties": false,

--- a/corokafka/corokafka_consumer_topic_entry.h
+++ b/corokafka/corokafka_consumer_topic_entry.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <chrono>
+#include <atomic>
 #include <corokafka/corokafka_utils.h>
 #include <corokafka/corokafka_message.h>
 #include <corokafka/corokafka_consumer_configuration.h>
@@ -72,7 +73,7 @@ struct ConsumerTopicEntry : TopicEntry {
     CommitterPtr                    _committer;
     PollingStrategyPtr              _roundRobin;
     mutable OffsetMap               _offsets;
-    bool                            _isPaused{false};
+    std::atomic<bool>               _isPaused{false};
     bool                            _setOffsetsOnStart{true};
     bool                            _pauseOnStart{false};
     bool                            _isSubscribed{true};

--- a/corokafka/impl/corokafka_producer_manager_impl.cpp
+++ b/corokafka/impl/corokafka_producer_manager_impl.cpp
@@ -458,13 +458,13 @@ void ProducerManagerImpl::throttleCallback(
                         std::chrono::milliseconds throttleDuration)
 {
     if (topicEntry._throttleControl.autoThrottle()) {
-        //calculate throttle periods
+        //calculate throttle status
         ThrottleControl::Status status = topicEntry._throttleControl.handleThrottleCallback(throttleDuration);
-        if (status._on) {
+        if (status == ThrottleControl::Status::On) {
             //Get partition metadata
             handle.pause(topicEntry._configuration.getTopic());
         }
-        else if (status._off) {
+        else if (status == ThrottleControl::Status::Off) {
             handle.resume(topicEntry._configuration.getTopic());
             topicEntry._forceSyncFlush = true;
         }


### PR DESCRIPTION
Make pause/resume atomic and prevent repeatedly calling into rdkafka if condition is already met.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
- Allow for various threads to simultaneously call pause/resume on a topic. The current logic would simply forward the call to the rdkafka layer, potentially causing multiple buffer flushes. 

**Testing performed**
- Pause from multiple threads and make sure only a single call was made to rdkafka.
