### PR TITLE
Set paused flag to true if pausing consumer on start

### DIFF
--- a/corokafka/corokafka_consumer_topic_entry.h
+++ b/corokafka/corokafka_consumer_topic_entry.h
@@ -75,7 +75,6 @@ struct ConsumerTopicEntry : TopicEntry {
     mutable OffsetMap               _offsets;
     std::atomic<bool>               _isPaused{false};
     bool                            _setOffsetsOnStart{true};
-    bool                            _pauseOnStart{false};
     bool                            _isSubscribed{true};
     bool                            _skipUnknownHeaders{true};
     quantum::ThreadContext<int>::Ptr _pollFuture{nullptr};

--- a/corokafka/impl/corokafka_consumer_manager_impl.cpp
+++ b/corokafka/impl/corokafka_consumer_manager_impl.cpp
@@ -206,12 +206,6 @@ void ConsumerManagerImpl::setup(const std::string& topic, ConsumerTopicEntry& to
     topicEntry._committer->set_error_callback(offsetCommitErrorFunc);
     
     //Set internal config options
-    const cppkafka::ConfigurationOption* pauseOnStart =
-        Configuration::findOption("internal.consumer.pause.on.start", internalOptions);
-    if (pauseOnStart) {
-        topicEntry._pauseOnStart = StringEqualCompare()(pauseOnStart->get_value(), "true");
-    }
-    
     const cppkafka::ConfigurationOption* skipUnknownHeaders =
         Configuration::findOption("internal.consumer.skip.unknown.headers", internalOptions);
     if (skipUnknownHeaders) {
@@ -368,7 +362,10 @@ void ConsumerManagerImpl::setup(const std::string& topic, ConsumerTopicEntry& to
         topicEntry._consumer->set_rebalance_error_callback(std::move(rebalanceErrorFunc));
     }
     
-    if (topicEntry._pauseOnStart) {
+    const cppkafka::ConfigurationOption* pauseOnStart =
+        Configuration::findOption("internal.consumer.pause.on.start", internalOptions);
+    if (pauseOnStart && StringEqualCompare()(pauseOnStart->get_value(), "true")) {
+        topicEntry._isPaused = true;
         topicEntry._consumer->pause(topic);
     }
     


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
Set paused flag to true if consumer is paused on start.

**Testing performed**
Start the consumer in paused mode. Made sure resume works afterwards and messages are received.