### PR TITLE
Added getLatency() API for produced messages

### DIFF
--- a/corokafka/corokafka_received_message.h
+++ b/corokafka/corokafka_received_message.h
@@ -208,7 +208,7 @@ private:
     void validateHeadersError() const;
     cppkafka::Error doCommit();
     
-    cppkafka::BackoffCommitter&  _committer;
+    cppkafka::BackoffCommitter& _committer;
     OffsetMap&                  _offsets;
     cppkafka::Message           _message;
     boost::any                  _key;

--- a/corokafka/corokafka_sent_message.cpp
+++ b/corokafka/corokafka_sent_message.cpp
@@ -109,5 +109,15 @@ rd_kafka_msg_status_t SentMessage::getStatus() const
 }
 #endif
 
+#if RD_KAFKA_VERSION >= RD_KAFKA_MESSAGE_LATENCY_SUPPORT_VERSION
+std::chrono::microseconds SentMessage::getLatency() const
+{
+    if (!_message) {
+        throw std::runtime_error("Latency not available");
+    }
+    return _message->get_latency();
+}
+#endif
+
 }
 }

--- a/corokafka/corokafka_sent_message.h
+++ b/corokafka/corokafka_sent_message.h
@@ -80,6 +80,14 @@ public:
     rd_kafka_msg_status_t getStatus() const;
 #endif
 
+#if RD_KAFKA_VERSION >= RD_KAFKA_MESSAGE_LATENCY_SUPPORT_VERSION
+    /**
+     * @brief Gets the message latency in microseconds as measured from the produce() call.
+     * @return The latency in microseconds
+     */
+    std::chrono::microseconds getLatency() const;
+#endif
+
 private:
     SentMessage(const cppkafka::Message& kafkaMessage, void* opaque);
     SentMessage(const cppkafka::MessageBuilder& builder, cppkafka::Error error, void* opaque);
@@ -87,7 +95,7 @@ private:
     const cppkafka::Message*          _message;
     const cppkafka::MessageBuilder*   _builder;
     cppkafka::Error                   _error;
-    void*                   _opaque;
+    void*                             _opaque;
 };
 
 }}


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
Added `getLatency()` API for produced messages. This simply exposes `cppkafka::Message::get_latency()`.
