### PR TITLE
Updated drain default parameter to reflect quantum::dispatcher::drain…

### DIFF
--- a/corokafka/corokafka_connector.h
+++ b/corokafka/corokafka_connector.h
@@ -80,14 +80,14 @@ public:
     
     /**
      * @brief Gracefully shut down the connector.
-     * @param drainTimeout Specify a timeout to apply if draining (see below). Set to 0 to wait for all tasks.
+     * @param drainTimeout Specify a timeout to apply if draining (see below). Set to -1 to wait indefinitely.
      * @details This will purge all internal producer queues and unsubscribe all consumers. Any pending
      *          poll tasks will run to completion including raising appropriate callbacks.
      * @remark Note that shutdown is automatically called in the Connector destructor.
      * @remark If this connector owns the internal dispatcher (i.e. was not constructed using an externally-supplied
      *         dispatcher) it will also drain all running tasks.
      */
-    void shutdown(std::chrono::milliseconds drainTimeout = std::chrono::milliseconds::zero());
+    void shutdown(std::chrono::milliseconds drainTimeout = std::chrono::milliseconds(-1));
     
 private:
     //members

--- a/corokafka/impl/corokafka_connector_impl.cpp
+++ b/corokafka/impl/corokafka_connector_impl.cpp
@@ -66,9 +66,6 @@ void ConnectorImpl::shutdown(bool drain,
         }
         
         if (drain) {
-            if (drainTimeout.count() < 0) {
-                drainTimeout = std::chrono::milliseconds::zero();
-            }
             _dispatcher.drain(drainTimeout, true);
         }
     }


### PR DESCRIPTION
Updated drain default parameter to reflect `quantum::dispatcher::drain()` default parameter

Signed-off-by: Alexander Damian <adamian@bloomberg.net>

