### PR TITLE
Adjust current offset on start for OffsetManager.

### DIFF
--- a/corokafka/impl/corokafka_consumer_manager_impl.cpp
+++ b/corokafka/impl/corokafka_consumer_manager_impl.cpp
@@ -116,9 +116,6 @@ void ConsumerManagerImpl::setup(const std::string& topic, ConsumerTopicEntry& to
         throw InvalidOptionException(topic, Configuration::RdKafkaOptions::groupId, "Missing");
     }
     
-    //Check if the receiver is set (will throw if not set)
-    topicEntry._configuration.getTypeErasedReceiver();
-    
     //Set the rdkafka configuration options
     cppkafka::Configuration kafkaConfig(rdKafkaOptions);
     kafkaConfig.set_default_topic_configuration(cppkafka::TopicConfiguration(rdKafkaTopicOptions));

--- a/tests/corokafka_tests_callbacks.h
+++ b/tests/corokafka_tests_callbacks.h
@@ -24,10 +24,12 @@ struct CallbackCounters
         _partitioner = 0;
         _queueFull = 0;
         _offsetCommit = 0;
+        _maxProcessedOffsets = -1;
         _assign = 0;
         _revoke = 0;
         _rebalance = 0;
         _offsetCommitPartitions.clear();
+        _numOffsetCommitted.clear();
         _receiver = 0;
         _eof = 0;
         _skip = 0;
@@ -48,7 +50,9 @@ struct CallbackCounters
     int _partitioner{0};
     int _queueFull{0};
     std::atomic_int _offsetCommit{0};
+    std::map<cppkafka::TopicPartition, int> _numOffsetCommitted;
     std::map<cppkafka::TopicPartition, int> _offsetCommitPartitions;
+    int _maxProcessedOffsets{-1};
     int _assign{0};
     int _revoke{0};
     int _rebalance{0};


### PR DESCRIPTION
**Changes**
Adjust current offset on start for the `OffsetManager`.
Add tests for relative and stored offset consumption.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>