### PR TITLE
Named corokafka thread (unix only)

### DIFF
--- a/corokafka/impl/corokafka_connector_impl.cpp
+++ b/corokafka/impl/corokafka_connector_impl.cpp
@@ -37,6 +37,9 @@ ConnectorImpl::ConnectorImpl(const ConfigurationBuilder& builder,
     _pollThread(std::bind(&ConnectorImpl::poll, this))
 {
     maxMessageBuilderOutputLength() = _config.getMaxMessagePayloadOutputLength();
+#if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 12)
+    setThreadName(_pollThread.native_handle(), "poll:", 0);
+#endif
 }
 
 ConnectorImpl::ConnectorImpl(ConfigurationBuilder&& builder,
@@ -54,6 +57,9 @@ ConnectorImpl::ConnectorImpl(ConfigurationBuilder&& builder,
     _pollThread(std::bind(&ConnectorImpl::poll, this))
 {
     maxMessageBuilderOutputLength() = _config.getMaxMessagePayloadOutputLength();
+#if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 12)
+    setThreadName(_pollThread.native_handle(), "poll:", 0);
+#endif
 }
 
 void ConnectorImpl::shutdown(bool drain,


### PR DESCRIPTION
GDB output
```
Thread 0x7fffda7f4700 (LWP 17260) "corokf:poll:0"   0x00007ffff7887e9d 
in nanosleep () from /usr/lib64/libpthread.so.0
```
Signed-off-by: Alexander Damian <adamian@bloomberg.net>
