### PR TITLE
Finish poll cycle during shutdown 

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,6 +1,7 @@
 # Configuration
 
 The following configuration options are complementary to the RdKafka [options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) and affect exclusively the functionality of this library.
+**Note that values `-1` and `-2` carry special meanings.**
           
 ## Connector configuration
 
@@ -19,7 +20,8 @@ The following configuration options are complementary to the RdKafka [options](h
 | internal.consumer.timeout.ms | \>= -1 | 1000 | Sets the timeout on any operations requiring a timeout such as poll, query offsets, etc. Set to **-1** for infinite timeout. |
 | internal.consumer.startup.timeout.ms | \>= -1 | 1000 | Sets the timeout on startup operations such as partition assignment and subscriptions in cases when brokers may take longer to come up. |
 | internal.consumer.poll.timeout.ms | \>= -1 | N/A | If set, overrides the 'internal.consumer.timeout.ms' default setting for polling only. Set to **-1** for infinite timeout. |
-| internal.consumer.auto.offset.persist | true, false | false | Enables auto-commit/auto-store inside the `ReceivedMessage` destructor. |
+| internal.consumer.min.poll.interval.ms | -2, \> 0 | 10 | Recurring time interval for which to block and wait for messages. This allows for faster shutdown detection. The cumulative time for all intervals shall not exceed **internal.consumer.poll.timeout.ms**. To disable, set to **-2**. If **internal.consumer.poll.timeout.ms** is infinite, this interval cannot be disabled. |
+| internal.consumer.auto.offset.persist | true, false | true | Enables auto-commit/auto-store inside the `ReceivedMessage` destructor. |
 | internal.consumer.auto.offset.persist.on.exception | true, false | false | Dictates if the offset persist should be aborted as a result of an exception. This could allow the application to reprocess a message following an exception. This is only valid if **internal.consumer.auto.offset.persist=true**. |
 | internal.consumer.offset.persist.strategy | commit, store | store | Determines if offsets are committed or stored locally. Some RdKafka settings will be changed according to **note 2** below. If **store** is chosen, **auto.commit.interval.ms > 0** must be set. Note that the **store** option is only valid for RdKafka versions >= **0.9.5.1** |
 | internal.consumer.commit.exec | sync, async | async | Dictates if offset commits should be synchronous or asynchronous. |
@@ -28,7 +30,7 @@ The following configuration options are complementary to the RdKafka [options](h
 | internal.consumer.commit.backoff.interval.ms | \> 0 | 100 | Time in ms between retries. |
 | internal.consumer.commit.max.backoff.ms | \>= **internal.consumer.commit.backoff.interval.ms** | 1000 | Maximum back-off time for retries. If set, this has higher precedence than **internal.consumer.commit.num.retries**. |
 | internal.consumer.poll.strategy | batch, serial, roundrobin | serial | Determines how messages are read from RdKafka queues. The **batch** strategy is to read the entire batch of messages from the main consumer queue and is more _performant_. If **roundrobin** strategy is selected, messages are read in round-robin fashion from each partition at a time. In this mode, the **timeout.ms** and **poll.timeout.ms** are divided by the **read.size** up to a minimum of **roundrobin.min.timeout.ms**. |
-| internal.consumer.roundrobin.min.poll.timeout.ms | \> 0 | 10 | Minimum poll timeout when consuming messages in **roundrobin** mode. |
+| internal.consumer.roundrobin.min.poll.timeout.ms | \> 0 | 10 | Deprecated. See **internal.consumer.poll.interval.timeout.ms** |
 | internal.consumer.read.size | -1, \> 0 | 100 | Number of messages to read on each poll interval. In **roundrobin** or **serial** mode, setting this to -1 will block the **internal.consumer.poll.io.thread.id** thread exclusively for polling until the Consumer is destroyed. See `ConnectorConfiguration::setPollInterval()` for more details.|
 | internal.consumer.message.prefetch | true, false | false | If **internal.consumer.poll.strategy=batch**, start pre-fetching the next series of messages while processing the current ones. This increases performance but may cause additional burden on the broker. |
 | internal.consumer.receive.callback.thread.range.low | [0, \<quantum_IO_threads\>) | 0 | Specifies the lowest thread id on which receive callbacks will be called. See **note 1** below for more details. |

--- a/corokafka/corokafka_consumer_configuration.cpp
+++ b/corokafka/corokafka_consumer_configuration.cpp
@@ -262,6 +262,13 @@ const Configuration::OptionMap ConsumerConfiguration::s_internalOptions = {
         if (value) *reinterpret_cast<std::chrono::milliseconds*>(value) = temp;
         return true;
      }},
+     {Options::minPollIntervalMs,
+     [](const std::string& topic, const cppkafka::ConfigurationOption* option, void* value)->bool{
+        if (!option) return false;
+        std::chrono::milliseconds temp{Configuration::extractCounterValue(topic, Options::minPollIntervalMs, *option, 1)};
+        if (value) *reinterpret_cast<std::chrono::milliseconds*>(value) = temp;
+        return true;
+     }},
     {Options::skipUnknownHeaders,
      [](const std::string& topic, const cppkafka::ConfigurationOption* option, void* value)->bool{
         if (!option) return false;

--- a/corokafka/corokafka_consumer_configuration.h
+++ b/corokafka/corokafka_consumer_configuration.h
@@ -48,13 +48,14 @@ public:
         static constexpr const char* autoOffsetPersistOnException =     "internal.consumer.auto.offset.persist.on.exception";
         static constexpr const char* autoThrottle =                     "internal.consumer.auto.throttle";
         static constexpr const char* autoThrottleMultiplier =           "internal.consumer.auto.throttle.multiplier";
+        static constexpr const char* batchPrefetch =                    "internal.consumer.batch.prefetch";
         static constexpr const char* commitBackoffStrategy =            "internal.consumer.commit.backoff.strategy";
         static constexpr const char* commitBackoffIntervalMs =          "internal.consumer.commit.backoff.interval.ms";
         static constexpr const char* commitExec =                       "internal.consumer.commit.exec";
         static constexpr const char* commitMaxBackoffMs =               "internal.consumer.commit.max.backoff.ms";
         static constexpr const char* commitNumRetries =                 "internal.consumer.commit.num.retries";
         static constexpr const char* logLevel =                         "internal.consumer.log.level";
-        static constexpr const char* batchPrefetch =                    "internal.consumer.batch.prefetch";
+        static constexpr const char* minPollIntervalMs =                "internal.consumer.min.poll.interval.ms";
         static constexpr const char* offsetPersistStrategy =            "internal.consumer.offset.persist.strategy";
         static constexpr const char* pauseOnStart =                     "internal.consumer.pause.on.start";
         static constexpr const char* pollIoThreadId =                   "internal.consumer.poll.io.thread.id";
@@ -68,7 +69,7 @@ public:
         static constexpr const char* receiveCallbackThreadRangeLow =    "internal.consumer.receive.callback.thread.range.low";
         static constexpr const char* receiveCallbackThreadRangeHigh =   "internal.consumer.receive.callback.thread.range.high";
         static constexpr const char* receiveInvokeThread =              "internal.consumer.receive.invoke.thread";
-        static constexpr const char* minRoundRobinPollTimeoutMs =       "internal.consumer.min.roundrobin.poll.timeout.ms";
+        static constexpr const char* minRoundRobinPollTimeoutMs =       "internal.consumer.min.roundrobin.poll.timeout.ms"; //deprecated
         static constexpr const char* skipUnknownHeaders =               "internal.consumer.skip.unknown.headers";
         static constexpr const char* timeoutMs =                        "internal.consumer.timeout.ms";
         static constexpr const char* startupTimeoutMs =                 "internal.consumer.startup.timeout.ms";

--- a/corokafka/corokafka_consumer_topic_entry.h
+++ b/corokafka/corokafka_consumer_topic_entry.h
@@ -84,10 +84,10 @@ struct ConsumerTopicEntry {
     cppkafka::Queue                 _eventQueue; //queue event polling
     cppkafka::TopicPartitionList    _partitionAssignment;
     CommitterPtr                    _committer;
-    PollStrategyBasePtr             _poller;
+    PollStrategyBasePtr             _roundRobinPoller;
     PollStrategy                    _pollStrategy{PollStrategy::Serial};
     OffsetMap                       _offsets;
-    OffsetWatermarkList   _watermarks;
+    OffsetWatermarkList             _watermarks;
     bool                            _enableWatermarkCheck{false};
     std::atomic_bool                _isPaused{false};
     bool                            _setOffsetsOnStart{true};
@@ -98,7 +98,7 @@ struct ConsumerTopicEntry {
     quantum::IQueue::QueueId        _processCoroThreadId{quantum::IQueue::QueueId::Any};
     quantum::IQueue::QueueId        _pollIoThreadId{quantum::IQueue::QueueId::Any};
     std::chrono::milliseconds       _pollTimeout{EnumValue(TimerValues::Disabled)};
-    std::chrono::milliseconds       _minRoundRobinPollTimeout{10};
+    std::chrono::milliseconds       _minPollInterval{EnumValue(TimerValues::Disabled)};
     std::pair<int,int>              _coroQueueIdRangeForAny;
     int                             _numIoThreads;
     std::pair<int,int>              _receiveCallbackThreadRange;

--- a/corokafka/impl/corokafka_received_message_impl.h
+++ b/corokafka/impl/corokafka_received_message_impl.h
@@ -251,14 +251,14 @@ cppkafka::Error ReceivedMessageImpl<KEY,PAYLOAD,HEADERS>::commit(const void* opa
 
 template <typename KEY, typename PAYLOAD, typename HEADERS>
 cppkafka::Error ReceivedMessageImpl<KEY,PAYLOAD,HEADERS>::commit(ExecMode execMode,
-                                                             const void* opaque)
+                                                                 const void* opaque)
 {
     if (!_message) {
         return RD_KAFKA_RESP_ERR__BAD_MSG;
     }
-    if (_message.is_eof()) {
+    if (_message.get_error()) {
         //nothing to commit
-        return RD_KAFKA_RESP_ERR__PARTITION_EOF;
+        return _message.get_error();
     }
     _opaque = opaque;
     if ((_opaque != nullptr) &&

--- a/tests/corokafka_tests_3_consumer.cpp
+++ b/tests/corokafka_tests_3_consumer.cpp
@@ -155,7 +155,14 @@ TEST(ConsumerConfiguration, InternalConsumerPollTimeoutMs)
 
 TEST(ConsumerConfiguration, InternalConsumerRoundRobinMinPollTimeoutMs)
 {
+    //Deprecated
     testConsumerOption<InvalidOptionException>("InvalidOptionException", "internal.consumer.min.roundrobin.poll.timeout.ms",
+        {{"0",true},{"10",false}});
+}
+
+TEST(ConsumerConfiguration, InternalConsumerMinPollIntervalMs)
+{
+    testConsumerOption<InvalidOptionException>("InvalidOptionException", "internal.consumer.min.poll.interval.ms",
         {{"0",true},{"10",false}});
 }
 


### PR DESCRIPTION
### Description of changes
* Finish poll cycle during shutdown to allow pending callbacks to be raised.
* Check for shutdown right before delivering the message.
* Don't commit message offset if the message has _any_ error, not just `EOF`.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>
