### PR TITLE
Removed .at() access to allow for clearer exception messages

### DIFF
--- a/corokafka/corokafka_configuration.cpp
+++ b/corokafka/corokafka_configuration.cpp
@@ -335,5 +335,18 @@ cppkafka::LogLevel Configuration::extractLogLevel(const std::string& topic,
     throw InvalidOptionException(topic, optionName, level);
 }
 
+const Configuration::OptionExtractorFunc&
+Configuration::extractOption(const OptionMap& options,
+                             const std::string& option)
+{
+    auto it = options.find(option);
+    if (it == options.end()) {
+        std::ostringstream oss;
+        oss << "Invalid option: " << option;
+        throw std::out_of_range(oss.str());
+    }
+    return it->second;
+}
+
 }
 }

--- a/corokafka/corokafka_configuration.h
+++ b/corokafka/corokafka_configuration.h
@@ -114,6 +114,9 @@ protected:
     static cppkafka::LogLevel extractLogLevel(const std::string& topic,
                                               const char* optionName,
                                               const std::string &level);
+    static const OptionExtractorFunc& extractOption(const OptionMap& options,
+                                                    const std::string& option);
+    
     // Members
     std::array<OptionList, 3>  _options; //indexed by OptionType
 };

--- a/corokafka/corokafka_connector_configuration.cpp
+++ b/corokafka/corokafka_connector_configuration.cpp
@@ -110,7 +110,7 @@ const Callbacks::ConnectorLogCallback& ConnectorConfiguration::getLogCallback() 
 const Configuration::OptionExtractorFunc&
 ConnectorConfiguration::extract(const std::string& option)
 {
-    return s_internalOptions.at(option);
+    return Configuration::extractOption(s_internalOptions, option);
 }
 
 }

--- a/corokafka/corokafka_consumer_configuration.cpp
+++ b/corokafka/corokafka_consumer_configuration.cpp
@@ -360,7 +360,7 @@ const Receiver& ConsumerConfiguration::getTypeErasedReceiver() const
 const Configuration::OptionExtractorFunc&
 ConsumerConfiguration::extract(const std::string& option)
 {
-    return s_internalOptions.at(option);
+    return Configuration::extractOption(s_internalOptions, option);
 }
 
 }

--- a/corokafka/corokafka_header_pack.cpp
+++ b/corokafka/corokafka_header_pack.cpp
@@ -140,8 +140,7 @@ size_t HeaderPack::numValidHeaders() const {
 
 bool HeaderPack::isValidAt(size_t index) const
 {
-    const auto& entry = _headers.at(index);
-    return !entry.second.empty();
+    return !_headers.at(index).second.empty();
 }
 
 bool HeaderPack::isValid(const std::string& name, size_t relativePosition) const

--- a/corokafka/corokafka_producer_configuration.cpp
+++ b/corokafka/corokafka_producer_configuration.cpp
@@ -174,7 +174,7 @@ const Callbacks::QueueFullCallback& ProducerConfiguration::getQueueFullCallback(
 const Configuration::OptionExtractorFunc&
 ProducerConfiguration::extract(const std::string& option)
 {
-    return s_internalOptions.at(option);
+    return Configuration::extractOption(s_internalOptions, option);
 }
 
 }

--- a/corokafka/corokafka_type_erased_deserializer.h
+++ b/corokafka/corokafka_type_erased_deserializer.h
@@ -43,9 +43,9 @@ struct TypeErasedDeserializer
         };
     }
     
-    DeserializerPtr                         _keyDeserializer;
-    DeserializerPtr                         _payloadDeserializer;
-    DeserializerMap                         _headerDeserializers;
+    DeserializerPtr                               _keyDeserializer;
+    DeserializerPtr                               _payloadDeserializer;
+    DeserializerMap                               _headerDeserializers;
     std::vector<DeserializerMap::const_iterator>  _headerEntries;
 };
 


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>
