### PR TITLE
Generate a single warning per unknown header. Lock access to subscrib…

### DIFF
--- a/corokafka/impl/corokafka_consumer_manager_impl.h
+++ b/corokafka/impl/corokafka_consumer_manager_impl.h
@@ -133,10 +133,16 @@ public:
                                      const cppkafka::Message& rawMessage);
     static void assignmentCallback(ConsumerTopicEntry& topicEntry,
                                    cppkafka::TopicPartitionList& topicPartitions);
+    static void assignmentCallbackImpl(ConsumerTopicEntry& topicEntry,
+                                       cppkafka::TopicPartitionList& topicPartitions);
     static void revocationCallback(ConsumerTopicEntry& topicEntry,
                                    const cppkafka::TopicPartitionList& topicPartitions);
+    static void revocationCallbackImpl(ConsumerTopicEntry& topicEntry,
+                                       const cppkafka::TopicPartitionList& topicPartitions);
     static void rebalanceErrorCallback(ConsumerTopicEntry& topicEntry,
                                        cppkafka::Error error);
+    static void rebalanceErrorCallbackImpl(ConsumerTopicEntry& topicEntry,
+                                           cppkafka::Error error);
     //log + error callback wrapper
     static void report(ConsumerTopicEntry& topicEntry,
                        cppkafka::LogLevel level,


### PR DESCRIPTION
### Changes
* Generate a single warning per unknown header. 
* Lock access to subscribing/unsubscribing consumers in case of slight but potential race-condition in case the application calls subscribe/unsubscribe while there's an ongoing rebalance callback executing.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>
