### PR TITLE
Added validity check for HeaderPack

### DIFF
--- a/corokafka/corokafka_header_pack.cpp
+++ b/corokafka/corokafka_header_pack.cpp
@@ -152,5 +152,19 @@ bool HeaderPack::isValid(const std::string& name, size_t relativePosition) const
     return !it->second.empty();
 }
 
+void HeaderPack::validateHeaderAt(size_t index) const
+{
+    if (!isValidAt(index)) {
+        throw InvalidArgumentException(0, "Header is invalid (empty)");
+    }
+}
+
+void HeaderPack::validateHeader(const std::string& name, size_t relativePosition) const
+{
+    if (!isValid(name, relativePosition)) {
+        throw InvalidArgumentException(0, "Header is invalid (empty)");
+    }
+}
+
 }
 }

--- a/corokafka/corokafka_header_pack.h
+++ b/corokafka/corokafka_header_pack.h
@@ -202,6 +202,8 @@ private:
     ListType::const_iterator getImpl(const std::string& name, size_t relativePosition) const;
     ListType::iterator getImpl(const std::string& name, size_t relativePosition);
     HeaderNode& operator[](size_t index);
+    void validateHeaderAt(size_t index) const;
+    void validateHeader(const std::string& name, size_t relativePosition) const;
     
     // Members
     ListType    _headers;

--- a/corokafka/impl/corokafka_header_pack_impl.h
+++ b/corokafka/impl/corokafka_header_pack_impl.h
@@ -16,6 +16,8 @@
 #ifndef BLOOMBERG_COROKAFKA_HEADER_PACK_IMPL_H
 #define BLOOMBERG_COROKAFKA_HEADER_PACK_IMPL_H
 
+#include <corokafka/corokafka_exception.h>
+
 namespace Bloomberg {
 namespace corokafka {
 
@@ -31,33 +33,39 @@ HeaderPack& HeaderPack::push_back(const std::string& name, H&& header) {
 
 template <typename H>
 const H& HeaderPack::get(const std::string& name, size_t relativePosition) const & {
+    validateHeader(name, relativePosition);
     return boost::any_cast<const H&>(getImpl(name, relativePosition)->second);
 }
 
 template <typename H>
 H& HeaderPack::get(const std::string& name, size_t relativePosition) & {
+    validateHeader(name, relativePosition);
     return boost::any_cast<H&>(getImpl(name, relativePosition)->second);
 }
 
 template <typename H>
 H&& HeaderPack::get(const std::string& name, size_t relativePosition) && {
+    validateHeader(name, relativePosition);
     return boost::any_cast<H&&>(std::move(getImpl(name, relativePosition)->second));
 }
 
 template <typename H>
 HeaderRef<const H&> HeaderPack::getAt(size_t index) const & {
+    validateHeaderAt(index);
     const auto& entry = _headers.at(index);
     return HeaderRef<const H&>(entry.first, boost::any_cast<const H&>(entry.second));
 }
 
 template <typename H>
 HeaderRef<H&> HeaderPack::getAt(size_t index) & {
+    validateHeaderAt(index);
     auto& entry = _headers.at(index);
     return HeaderRef<H&>(entry.first, boost::any_cast<H&>(entry.second));
 }
 
 template <typename H>
 HeaderRef<H&&> HeaderPack::getAt(size_t index) && {
+    validateHeaderAt(index);
     auto& entry = _headers.at(index);
     return HeaderRef<H&&>(entry.first, boost::any_cast<H&&>(std::move(entry.second)));
 }


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

**Describe your changes**
Added check for header validity. This will throw an `InvalidArgumentException` instead of crashing when the iterator is invalid.
