### PR TITLE
Update watermark on each message

### DIFF
--- a/corokafka/corokafka_consumer_topic_entry.h
+++ b/corokafka/corokafka_consumer_topic_entry.h
@@ -103,7 +103,6 @@ struct ConsumerTopicEntry {
     Subscription                    _subscription;
     OffsetMap                       _offsets;
     OffsetWatermarkList             _watermarks;
-    bool                            _enableWatermarkCheck{false};
     std::atomic_bool                _isPaused{false};
     bool                            _skipUnknownHeaders{true};
     quantum::ThreadContextPtr<int>  _pollFuture{nullptr};

--- a/corokafka/impl/corokafka_consumer_manager_impl.h
+++ b/corokafka/impl/corokafka_consumer_manager_impl.h
@@ -233,6 +233,9 @@ private:
                                       ExecMode execMode,
                                       const void* opaque);
     
+    static void raiseWatermark(ConsumerTopicEntry& entry,
+                               const cppkafka::TopicPartition& toppar);
+    
     // Members
     quantum::Dispatcher&            _dispatcher;
     const ConnectorConfiguration&   _connectorConfiguration;


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>

Watermarks were sometimes not updated properly which caused consumers to stall until a new batch of messages would arrive even though there were still messages on the partition. Now we update the watermark levels inside the offset commit callback (internal to corokafka) which ensures that they will always be up to date.