### PR TITLE
Added broker timeout for metadata operations

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -18,7 +18,7 @@ The following configuration options are complementary to the RdKafka [options](h
 | :------- | :---: | :-----: | :---------- |
 | internal.consumer.pause.on.start | true, false | false | Start the consumer in paused state. User needs to call `resume()` to consume. |
 | internal.consumer.timeout.ms | \>= -1 | 1000 | Sets the timeout on any operations requiring a timeout such as poll, query offsets, etc. Set to **-1** for infinite timeout. |
-| internal.consumer.startup.timeout.ms | \>= -1 | 1000 | Sets the timeout on startup operations such as partition assignment and subscriptions in cases when brokers may take longer to come up. |
+| internal.consumer.startup.timeout.ms | \>= -1 | 1000 | Alias for 'internal.topic.broker.timeout.ms' (deprecated) |
 | internal.consumer.poll.timeout.ms | \>= -1 | N/A | If set, overrides the 'internal.consumer.timeout.ms' default setting for polling only. Set to **-1** for infinite timeout. |
 | internal.consumer.min.poll.interval.ms | -2, \> 0 | 10 | Recurring time interval for which to block and wait for messages. This allows for faster shutdown detection. The cumulative time for all intervals shall not exceed **internal.consumer.poll.timeout.ms**. To disable, set to **-2**. If **internal.consumer.poll.timeout.ms** is infinite, this interval cannot be disabled. |
 | internal.consumer.auto.offset.persist | true, false | true | Enables auto-commit/auto-store inside the `ReceivedMessage` destructor. |
@@ -67,6 +67,13 @@ The following configuration options are complementary to the RdKafka [options](h
 | internal.producer.sync.producer.thread.range.low | [0, \<quantum_io_threads\>) | 0 | When producing synchronously from a coroutine, use this to specify on which IO thread to produce. |
 | internal.producer.sync.producer.thread.range.high | [0, \<quantum_io_threads\>) | \<quantum_IO_threads\> - 1 | When producing synchronously from a coroutine, use this to specify on which IO thread to produce. |
 ---
+
+## Topic configuration
+
+| Property | Range | Default | Description |
+| :------- | :---: | :-----: | :---------- |
+| internal.topic.broker.timeout.ms | \>= -1 | 1000 | If set, overrides the 'internal.consumer.timeout.ms' and 'internal.producer.timeout.ms' for various operations such as metadata and watermark queries, partition assignments/subscriptions when brokers may take longer to respond. Particularly useful on startup when such queries are performed. Set to **-1** for infinite timeout. |
+
 
 ##### Notes
 

--- a/corokafka/corokafka_configuration.cpp
+++ b/corokafka/corokafka_configuration.cpp
@@ -339,13 +339,18 @@ cppkafka::LogLevel Configuration::extractLogLevel(const std::string& topic,
 
 const Configuration::OptionExtractorFunc&
 Configuration::extractOption(const OptionMap& options,
+                             const OptionMap& topicOptions,
                              const std::string& option)
 {
     auto it = options.find(option);
     if (it == options.end()) {
-        std::ostringstream oss;
-        oss << "Invalid option: " << option;
-        throw std::out_of_range(oss.str());
+        auto topicIt = topicOptions.find(option);
+        if (topicIt == options.end()) {
+            std::ostringstream oss;
+            oss << "Invalid option: " << option;
+            throw std::out_of_range(oss.str());
+        }
+        return topicIt->second;
     }
     return it->second;
 }

--- a/corokafka/corokafka_configuration.h
+++ b/corokafka/corokafka_configuration.h
@@ -115,6 +115,7 @@ protected:
                                               const char* optionName,
                                               const std::string &level);
     static const OptionExtractorFunc& extractOption(const OptionMap& options,
+                                                    const OptionMap& topicOptions,
                                                     const std::string& option);
     
     // Members

--- a/corokafka/corokafka_connector_configuration.cpp
+++ b/corokafka/corokafka_connector_configuration.cpp
@@ -110,7 +110,7 @@ const Callbacks::ConnectorLogCallback& ConnectorConfiguration::getLogCallback() 
 const Configuration::OptionExtractorFunc&
 ConnectorConfiguration::extract(const std::string& option)
 {
-    return Configuration::extractOption(s_internalOptions, option);
+    return Configuration::extractOption(s_internalOptions, {}, option);
 }
 
 }

--- a/corokafka/corokafka_consumer_configuration.cpp
+++ b/corokafka/corokafka_consumer_configuration.cpp
@@ -292,8 +292,6 @@ const Configuration::OptionMap ConsumerConfiguration::s_internalOptions = {
      }}
 };
 
-const Configuration::OptionMap ConsumerConfiguration::s_internalTopicOptions;
-
 PartitionStrategy ConsumerConfiguration::getPartitionStrategy() const
 {
     return _strategy;
@@ -360,7 +358,7 @@ const Receiver& ConsumerConfiguration::getTypeErasedReceiver() const
 const Configuration::OptionExtractorFunc&
 ConsumerConfiguration::extract(const std::string& option)
 {
-    return Configuration::extractOption(s_internalOptions, option);
+    return Configuration::extractOption(s_internalOptions, s_internalTopicOptions, option);
 }
 
 }

--- a/corokafka/corokafka_consumer_configuration.h
+++ b/corokafka/corokafka_consumer_configuration.h
@@ -72,7 +72,7 @@ public:
         static constexpr const char* minRoundRobinPollTimeoutMs =       "internal.consumer.min.roundrobin.poll.timeout.ms"; //deprecated
         static constexpr const char* skipUnknownHeaders =               "internal.consumer.skip.unknown.headers";
         static constexpr const char* timeoutMs =                        "internal.consumer.timeout.ms";
-        static constexpr const char* startupTimeoutMs =                 "internal.consumer.startup.timeout.ms";
+        static constexpr const char* startupTimeoutMs =                 "internal.consumer.startup.timeout.ms"; //deprecated
     };
     
     /**
@@ -184,7 +184,6 @@ private:
     cppkafka::TopicPartitionList            _initialPartitionList;
     PartitionStrategy                       _strategy{PartitionStrategy::Dynamic};
     static const OptionMap                  s_internalOptions;
-    static const OptionMap                  s_internalTopicOptions;
     static const std::string                s_internalOptionsPrefix;
 };
 

--- a/corokafka/corokafka_consumer_metadata.cpp
+++ b/corokafka/corokafka_consumer_metadata.cpp
@@ -26,8 +26,9 @@ namespace corokafka {
 
 ConsumerMetadata::ConsumerMetadata(const std::string& topic,
                                    cppkafka::Consumer* handle,
-                                   PartitionStrategy strategy) :
-    ImplType(std::make_shared<ConsumerMetadataImpl>(topic, handle, strategy)),
+                                   PartitionStrategy strategy,
+                                   std::chrono::milliseconds brokerTimeout) :
+    ImplType(std::make_shared<ConsumerMetadataImpl>(topic, handle, strategy, brokerTimeout)),
     Metadata(std::static_pointer_cast<ConsumerMetadataImpl>(ImplType::impl()))
 {
 }
@@ -35,8 +36,9 @@ ConsumerMetadata::ConsumerMetadata(const std::string& topic,
 ConsumerMetadata::ConsumerMetadata(const std::string& topic,
                                    const cppkafka::Topic& kafkaTopic,
                                    cppkafka::Consumer* handle,
-                                   PartitionStrategy strategy) :
-    ImplType(std::make_shared<ConsumerMetadataImpl>(topic, kafkaTopic, handle, strategy)),
+                                   PartitionStrategy strategy,
+                                   std::chrono::milliseconds brokerTimeout) :
+    ImplType(std::make_shared<ConsumerMetadataImpl>(topic, kafkaTopic, handle, strategy, brokerTimeout)),
     Metadata(std::static_pointer_cast<ConsumerMetadataImpl>(ImplType::impl()))
 {
 }

--- a/corokafka/corokafka_consumer_metadata.h
+++ b/corokafka/corokafka_consumer_metadata.h
@@ -88,15 +88,17 @@ private:
     
     ConsumerMetadata(const std::string& topic,
                      cppkafka::Consumer* handle,
-                     PartitionStrategy strategy);
+                     PartitionStrategy strategy,
+                     std::chrono::milliseconds brokerTimeout = std::chrono::milliseconds{EnumValue(TimerValues::Disabled)});
     
     ConsumerMetadata(const std::string& topic,
                      const cppkafka::Topic& kafkaTopic,
                      cppkafka::Consumer* handle,
-                     PartitionStrategy strategy);
+                     PartitionStrategy strategy,
+                     std::chrono::milliseconds brokerTimeout = std::chrono::milliseconds{EnumValue(TimerValues::Disabled)});
     
     //For mocking only
-    ConsumerMetadata(std::shared_ptr<IConsumerMetadata> impl);
+    explicit ConsumerMetadata(std::shared_ptr<IConsumerMetadata> impl);
 };
 
 }

--- a/corokafka/corokafka_consumer_topic_entry.h
+++ b/corokafka/corokafka_consumer_topic_entry.h
@@ -111,6 +111,7 @@ struct ConsumerTopicEntry {
     quantum::IQueue::QueueId        _pollIoThreadId{quantum::IQueue::QueueId::Any};
     std::chrono::milliseconds       _pollTimeout{EnumValue(TimerValues::Disabled)};
     std::chrono::milliseconds       _minPollInterval{EnumValue(TimerValues::Disabled)};
+    std::chrono::milliseconds       _brokerTimeout{EnumValue(TimerValues::Disabled)};
     std::pair<int,int>              _coroQueueIdRangeForAny;
     int                             _numIoThreads;
     std::pair<int,int>              _receiveCallbackThreadRange;

--- a/corokafka/corokafka_metadata.cpp
+++ b/corokafka/corokafka_metadata.cpp
@@ -26,8 +26,9 @@ namespace corokafka {
 // Constructor
 Metadata::Metadata(const std::string& topic,
                    const cppkafka::Topic& kafkaTopic,
-                   cppkafka::KafkaHandleBase* handle) :
-    VirtualImpl(std::make_shared<MetadataImpl>(topic, kafkaTopic, handle))
+                   cppkafka::KafkaHandleBase* handle,
+                   std::chrono::milliseconds brokerTimeout) :
+    VirtualImpl(std::make_shared<MetadataImpl>(topic, kafkaTopic, handle, brokerTimeout))
 {
 }
 

--- a/corokafka/corokafka_metadata.h
+++ b/corokafka/corokafka_metadata.h
@@ -98,7 +98,8 @@ protected:
     // Constructor
     Metadata(const std::string& topic,
              const cppkafka::Topic& kafkaTopic,
-             cppkafka::KafkaHandleBase* handle);
+             cppkafka::KafkaHandleBase* handle,
+             std::chrono::milliseconds brokerTimeout = std::chrono::milliseconds{EnumValue(TimerValues::Disabled)});
     
     using VirtualImpl<IMetadata>::VirtualImpl;
     

--- a/corokafka/corokafka_producer_configuration.cpp
+++ b/corokafka/corokafka_producer_configuration.cpp
@@ -139,8 +139,6 @@ const Configuration::OptionMap ProducerConfiguration::s_internalOptions = {
      }},
 };
 
-const Configuration::OptionMap ProducerConfiguration::s_internalTopicOptions;
-
 void ProducerConfiguration::setDeliveryReportCallback(Callbacks::DeliveryReportCallback callback)
 {
     _deliveryReportCallback = std::move(callback);
@@ -174,7 +172,7 @@ const Callbacks::QueueFullCallback& ProducerConfiguration::getQueueFullCallback(
 const Configuration::OptionExtractorFunc&
 ProducerConfiguration::extract(const std::string& option)
 {
-    return Configuration::extractOption(s_internalOptions, option);
+    return Configuration::extractOption(s_internalOptions, s_internalTopicOptions, option);
 }
 
 }

--- a/corokafka/corokafka_producer_configuration.h
+++ b/corokafka/corokafka_producer_configuration.h
@@ -124,7 +124,6 @@ private:
     Callbacks::PartitionerCallback              _partitionerCallback;
     Callbacks::QueueFullCallback                _queueFullCallback;
     static const OptionMap                      s_internalOptions;
-    static const OptionMap                      s_internalTopicOptions;
     static const std::string                    s_internalOptionsPrefix;
 };
 

--- a/corokafka/corokafka_producer_metadata.cpp
+++ b/corokafka/corokafka_producer_metadata.cpp
@@ -25,16 +25,18 @@ namespace corokafka {
 //=============================================================================
 
 ProducerMetadata::ProducerMetadata(const std::string& topic,
-                                   cppkafka::BufferedProducer<ByteArray>* producer) :
-    ImplType(std::make_shared<ProducerMetadataImpl>(topic, producer)),
+                                   cppkafka::BufferedProducer<ByteArray>* producer,
+                                   std::chrono::milliseconds brokerTimeout) :
+    ImplType(std::make_shared<ProducerMetadataImpl>(topic, producer, brokerTimeout)),
     Metadata(std::static_pointer_cast<ProducerMetadataImpl>(ImplType::impl()))
 {
 }
 
 ProducerMetadata::ProducerMetadata(const std::string& topic,
                                    const cppkafka::Topic& kafkaTopic,
-                                   cppkafka::BufferedProducer<ByteArray>* producer) :
-    ImplType(std::make_shared<ProducerMetadataImpl>(topic, kafkaTopic, producer)),
+                                   cppkafka::BufferedProducer<ByteArray>* producer,
+                                   std::chrono::milliseconds brokerTimeout) :
+    ImplType(std::make_shared<ProducerMetadataImpl>(topic, kafkaTopic, producer, brokerTimeout)),
     Metadata(std::static_pointer_cast<ProducerMetadataImpl>(ImplType::impl()))
 {
 }

--- a/corokafka/corokafka_producer_metadata.h
+++ b/corokafka/corokafka_producer_metadata.h
@@ -62,14 +62,16 @@ private:
     using ImplType = Impl<IProducerMetadata>;
     
     ProducerMetadata(const std::string& topic,
-                     cppkafka::BufferedProducer<ByteArray>* producer);
+                     cppkafka::BufferedProducer<ByteArray>* producer,
+                     std::chrono::milliseconds brokerTimeout = std::chrono::milliseconds{EnumValue(TimerValues::Disabled)});
     
     ProducerMetadata(const std::string& topic,
                      const cppkafka::Topic& kafkaTopic,
-                     cppkafka::BufferedProducer<ByteArray>* producer);
+                     cppkafka::BufferedProducer<ByteArray>* producer,
+                     std::chrono::milliseconds brokerTimeout = std::chrono::milliseconds{EnumValue(TimerValues::Disabled)});
     
     //For mocking only
-    ProducerMetadata(std::shared_ptr<IProducerMetadata> impl);
+    explicit ProducerMetadata(std::shared_ptr<IProducerMetadata> impl);
 };
 
 }}

--- a/corokafka/corokafka_producer_topic_entry.h
+++ b/corokafka/corokafka_producer_topic_entry.h
@@ -74,6 +74,7 @@ struct ProducerTopicEntry {
     quantum::ThreadFuturePtr<int>       _pollFuture{nullptr};
     std::chrono::milliseconds           _waitForAcksTimeout{EnumValue(TimerValues::Disabled)};
     std::chrono::milliseconds           _flushWaitForAcksTimeout{rd_kafka_version() >= RD_KAFKA_ZERO_TIMEOUT_FLUSH_FIX ? EnumValue(TimerValues::Disabled) : 100};
+    std::chrono::milliseconds           _brokerTimeout{EnumValue(TimerValues::Disabled)};
     bool                                _forceSyncFlush{false};
     bool                                _preserveMessageOrder{false};
     cppkafka::Producer::PayloadPolicy   _payloadPolicy{cppkafka::Producer::PayloadPolicy::COPY_PAYLOAD};

--- a/corokafka/corokafka_topic_configuration.cpp
+++ b/corokafka/corokafka_topic_configuration.cpp
@@ -20,6 +20,21 @@
 namespace Bloomberg {
 namespace corokafka {
 
+//========================================================================
+//                       TOPIC CONFIGURATION
+//========================================================================
+const std::string TopicConfiguration::s_internalTopicOptionsPrefix = "internal.topic.";
+
+const Configuration::OptionMap TopicConfiguration::s_internalTopicOptions = {
+     {Options::brokerTimeoutMs,
+     [](const std::string& topic, const cppkafka::ConfigurationOption* option, void* value)->bool{
+        if (!option) return false;
+        std::chrono::milliseconds temp{Configuration::extractCounterValue(topic, Options::brokerTimeoutMs, *option, (int)TimerValues::Unlimited)};
+        if (value) *reinterpret_cast<std::chrono::milliseconds*>(value) = temp;
+        return true;
+     }}
+};
+
 TopicConfiguration::TopicConfiguration(KafkaType type,
                                        const std::string& topic,
                                        OptionList options,
@@ -127,9 +142,7 @@ void TopicConfiguration::filterOptions()
     parseOptions(_topic, internalOptionsPrefix, internalOptions, _options, OptionsPermission::RdKafkaAllow);
     
     // Topic options parsing
-    const OptionMap& internalTopicOptions = (_type == KafkaType::Producer) ?
-        ProducerConfiguration::s_internalTopicOptions : ConsumerConfiguration::s_internalTopicOptions;
-    parseOptions(_topic, internalOptionsPrefix, internalTopicOptions, _topicOptions, OptionsPermission::RdKafkaAllow);
+    parseOptions(_topic, s_internalTopicOptionsPrefix, s_internalTopicOptions, _topicOptions, OptionsPermission::RdKafkaAllow);
 }
 
 }}

--- a/corokafka/corokafka_topic_configuration.h
+++ b/corokafka/corokafka_topic_configuration.h
@@ -28,6 +28,15 @@ class TopicConfiguration : public Configuration
 {
 public:
     /**
+     * @brief Internal CoroKafka-specific options for topics. They are used to control this
+     *        library's behavior for topics and are complementary to the RdKafka topic options.
+     *        For more details please read CONFIGURATION.md document.
+     */
+    struct Options {
+        static constexpr const char *brokerTimeoutMs = "internal.topic.broker.timeout.ms";
+    };
+    
+    /**
      * @brief Get the configuration type.
      * @return The type.
      */
@@ -131,6 +140,10 @@ protected:
                        const std::string& topic,
                        std::initializer_list<cppkafka::ConfigurationOption> options,
                        std::initializer_list<cppkafka::ConfigurationOption> topicOptions);
+    
+    static const OptionMap              s_internalTopicOptions;
+    static const std::string            s_internalTopicOptionsPrefix;
+    
 private:
     void filterOptions();
     

--- a/corokafka/impl/corokafka_consumer_metadata_impl.cpp
+++ b/corokafka/impl/corokafka_consumer_metadata_impl.cpp
@@ -25,8 +25,9 @@ namespace corokafka {
 
 ConsumerMetadataImpl::ConsumerMetadataImpl(const std::string& topic,
                                            cppkafka::Consumer* handle,
-                                           PartitionStrategy strategy) :
-    MetadataImpl(topic, cppkafka::Topic(), handle),
+                                           PartitionStrategy strategy,
+                                           std::chrono::milliseconds brokerTimeout) :
+    MetadataImpl(topic, cppkafka::Topic(), handle, brokerTimeout),
     _strategy(strategy)
 {
 }
@@ -34,8 +35,9 @@ ConsumerMetadataImpl::ConsumerMetadataImpl(const std::string& topic,
 ConsumerMetadataImpl::ConsumerMetadataImpl(const std::string& topic,
                                            const cppkafka::Topic& kafkaTopic,
                                            cppkafka::Consumer* handle,
-                                           PartitionStrategy strategy) :
-    MetadataImpl(topic, kafkaTopic, handle),
+                                           PartitionStrategy strategy,
+                                           std::chrono::milliseconds brokerTimeout) :
+    MetadataImpl(topic, kafkaTopic, handle, brokerTimeout),
     _strategy(strategy)
 {
 }
@@ -90,7 +92,7 @@ cppkafka::TopicPartitionList ConsumerMetadataImpl::queryCommittedOffsets() const
     if (!_handle) {
         throw HandleException("Null consumer");
     }
-    return static_cast<const cppkafka::Consumer*>(_handle)->get_offsets_committed(getPartitionAssignment());
+    return static_cast<const cppkafka::Consumer*>(_handle)->get_offsets_committed(getPartitionAssignment(), brokerTimeout());
 }
 
 cppkafka::TopicPartitionList ConsumerMetadataImpl::queryCommittedOffsets(std::chrono::milliseconds timeout) const
@@ -125,7 +127,7 @@ cppkafka::GroupInformation ConsumerMetadataImpl::getGroupInformation() const
     if (!_handle) {
         throw HandleException("Null consumer");
     }
-    return _handle->get_consumer_group(static_cast<const cppkafka::Consumer*>(_handle)->get_member_id());
+    return _handle->get_consumer_group(static_cast<const cppkafka::Consumer*>(_handle)->get_member_id(), brokerTimeout());
 }
 
 cppkafka::GroupInformation ConsumerMetadataImpl::getGroupInformation(std::chrono::milliseconds timeout) const
@@ -141,7 +143,7 @@ cppkafka::GroupInformationList ConsumerMetadataImpl::getAllGroupsInformation() c
     if (!_handle) {
         throw HandleException("Null consumer");
     }
-    return _handle->get_consumer_groups();
+    return _handle->get_consumer_groups(brokerTimeout());
 }
 
 cppkafka::GroupInformationList ConsumerMetadataImpl::getAllGroupsInformation(std::chrono::milliseconds timeout) const

--- a/corokafka/impl/corokafka_consumer_metadata_impl.h
+++ b/corokafka/impl/corokafka_consumer_metadata_impl.h
@@ -28,12 +28,14 @@ class ConsumerMetadataImpl : public IConsumerMetadata,
 public:
     ConsumerMetadataImpl(const std::string& topic,
                          cppkafka::Consumer* handle,
-                         PartitionStrategy strategy);
+                         PartitionStrategy strategy,
+                         std::chrono::milliseconds brokerTimeout);
     
     ConsumerMetadataImpl(const std::string& topic,
                          const cppkafka::Topic& kafkaTopic,
                          cppkafka::Consumer* handle,
-                         PartitionStrategy strategy);
+                         PartitionStrategy strategy,
+                         std::chrono::milliseconds brokerTimeout);
     
     KafkaType getType() const final;
 

--- a/corokafka/impl/corokafka_metadata_impl.h
+++ b/corokafka/impl/corokafka_metadata_impl.h
@@ -29,7 +29,8 @@ public:
      */
     MetadataImpl(const std::string& topic,
                  const cppkafka::Topic& kafkaTopic,
-                 cppkafka::KafkaHandleBase* handle);
+                 cppkafka::KafkaHandleBase* handle,
+                 std::chrono::milliseconds brokerTimeout);
     MetadataImpl(const MetadataImpl&) = delete;
     MetadataImpl(MetadataImpl&&) = default;
     MetadataImpl& operator=(const MetadataImpl&) = delete;
@@ -39,12 +40,12 @@ public:
     
     OffsetWatermarkList queryOffsetWatermarks() const final;
     
-    OffsetWatermarkList queryOffsetWatermarks(std::chrono::milliseconds) const override;
+    OffsetWatermarkList queryOffsetWatermarks(std::chrono::milliseconds timeout) const override;
     
     cppkafka::TopicPartitionList queryOffsetsAtTime(Timestamp timestamp) const final;
     
     cppkafka::TopicPartitionList queryOffsetsAtTime(Timestamp timestamp,
-                                                    std::chrono::milliseconds) const override;
+                                                    std::chrono::milliseconds timeout) const override;
     explicit operator bool() const final;
     
     uint64_t getHandle() const final;
@@ -62,10 +63,13 @@ public:
     const cppkafka::Topic& getTopicObject() const final;
     
 protected:
+    std::chrono::milliseconds brokerTimeout() const;
+    
     const std::string*                      _topic;
     cppkafka::KafkaHandleBase*              _handle;
     mutable cppkafka::Topic                 _kafkaTopic;
     mutable cppkafka::TopicPartitionList    _partitions;
+    std::chrono::milliseconds               _brokerTimeout;
 };
 
 }}

--- a/corokafka/impl/corokafka_producer_manager_impl.h
+++ b/corokafka/impl/corokafka_producer_manager_impl.h
@@ -385,7 +385,8 @@ ProducerManagerImpl::postImpl(ExecMode mode,
     if (rc != 0) {
         DeliveryReport dr;
         dr.error(RD_KAFKA_RESP_ERR__BAD_MSG).opaque(opaque);
-        deliveryPromise.set(std::move(dr));
+        std::unique_ptr<PackedOpaque> packedOpaque(static_cast<PackedOpaque*>(builder.user_data()));
+        packedOpaque->_deliveryReportPromise.set(std::move(dr));
     }
     return deliveryFuture;
 }

--- a/corokafka/impl/corokafka_producer_metadata_impl.cpp
+++ b/corokafka/impl/corokafka_producer_metadata_impl.cpp
@@ -24,16 +24,18 @@ namespace corokafka {
 //=============================================================================
 
 ProducerMetadataImpl::ProducerMetadataImpl(const std::string& topic,
-                                           cppkafka::BufferedProducer<ByteArray>* producer) :
-    MetadataImpl(topic, cppkafka::Topic(), producer ? &producer->get_producer() : nullptr),
+                                           cppkafka::BufferedProducer<ByteArray>* producer,
+                                           std::chrono::milliseconds brokerTimeout) :
+    MetadataImpl(topic, cppkafka::Topic(), producer ? &producer->get_producer() : nullptr, brokerTimeout),
     _bufferedProducer(producer)
 {
 }
 
 ProducerMetadataImpl::ProducerMetadataImpl(const std::string& topic,
                                            const cppkafka::Topic& kafkaTopic,
-                                           cppkafka::BufferedProducer<ByteArray>* producer) :
-    MetadataImpl(topic, kafkaTopic, producer ? &producer->get_producer() : nullptr),
+                                           cppkafka::BufferedProducer<ByteArray>* producer,
+                                           std::chrono::milliseconds brokerTimeout) :
+    MetadataImpl(topic, kafkaTopic, producer ? &producer->get_producer() : nullptr, brokerTimeout),
     _bufferedProducer(producer)
 {
 }

--- a/corokafka/impl/corokafka_producer_metadata_impl.h
+++ b/corokafka/impl/corokafka_producer_metadata_impl.h
@@ -29,11 +29,13 @@ class ProducerMetadataImpl : public IProducerMetadata,
 {
 public:
     ProducerMetadataImpl(const std::string& topic,
-                         cppkafka::BufferedProducer<ByteArray>* producer);
+                         cppkafka::BufferedProducer<ByteArray>* producer,
+                         std::chrono::milliseconds brokerTimeout);
         
     ProducerMetadataImpl(const std::string& topic,
                          const cppkafka::Topic& kafkaTopic,
-                         cppkafka::BufferedProducer<ByteArray>* producer);
+                         cppkafka::BufferedProducer<ByteArray>* producer,
+                         std::chrono::milliseconds brokerTimeout);
 
     KafkaType getType() const final;
 

--- a/tests/corokafka_tests_2_producer.cpp
+++ b/tests/corokafka_tests_2_producer.cpp
@@ -7,6 +7,11 @@ namespace Bloomberg {
 namespace corokafka {
 namespace tests {
 
+//topic config
+Configuration::OptionList producerTopicConfig = {
+    {TopicConfiguration::Options::brokerTimeoutMs, 5000}
+};
+
 //sync
 Configuration::OptionList syncConfig = {
     {"enable.idempotence", false},
@@ -147,7 +152,7 @@ TEST(ProducerConfiguration, InternalProducerPollIoThreadId)
 
 TEST(Producer, SendSyncWithoutHeaders)
 {
-    Connector connector = makeProducerConnector(syncConfig, topicWithoutHeaders());
+    Connector connector = makeProducerConnector(syncConfig, producerTopicConfig, topicWithoutHeaders());
     
     //Send messages
     SenderId id = SenderId::SyncWithoutHeaders;
@@ -163,7 +168,7 @@ TEST(Producer, SendSyncWithoutHeaders)
 
 TEST(Producer, SendSyncWithHeaders)
 {
-    Connector connector = makeProducerConnector(syncConfig, topicWithHeaders());
+    Connector connector = makeProducerConnector(syncConfig, producerTopicConfig, topicWithHeaders());
     
     //Send messages
     SenderId id = SenderId::Sync;
@@ -181,7 +186,7 @@ TEST(Producer, SendSyncWithHeaders)
 
 TEST(Producer, SendSyncSkippingOneHeader)
 {
-    Connector connector = makeProducerConnector(syncConfig, topicWithHeaders());
+    Connector connector = makeProducerConnector(syncConfig, producerTopicConfig, topicWithHeaders());
     
     //Send messages
     SenderId id = SenderId::SyncSecondHeaderMissing;
@@ -198,7 +203,7 @@ TEST(Producer, SendSyncSkippingOneHeader)
 
 TEST(Producer, SendSyncSkippingBothHeaders)
 {
-    Connector connector = makeProducerConnector(syncConfig, topicWithHeaders());
+    Connector connector = makeProducerConnector(syncConfig, producerTopicConfig, topicWithHeaders());
     
     //Send messages
     SenderId id = SenderId::SyncBothHeadersMissing;
@@ -214,7 +219,7 @@ TEST(Producer, SendSyncSkippingBothHeaders)
 
 TEST(Producer, SendSyncUnorderedWithHeaders)
 {
-    Connector connector = makeProducerConnector(syncUnorderedConfig, topicWithHeaders());
+    Connector connector = makeProducerConnector(syncUnorderedConfig, producerTopicConfig, topicWithHeaders());
     
     //Send messages
     SenderId id = SenderId::SyncUnordered;
@@ -232,7 +237,7 @@ TEST(Producer, SendSyncUnorderedWithHeaders)
 
 TEST(Producer, SendSyncIdempotent)
 {
-    Connector connector = makeProducerConnector(syncIdempotentConfig, topicWithHeaders());
+    Connector connector = makeProducerConnector(syncIdempotentConfig, producerTopicConfig, topicWithHeaders());
     
     //Send messages
     SenderId id = SenderId::SyncIdempotent;
@@ -250,7 +255,7 @@ TEST(Producer, SendSyncIdempotent)
 
 TEST(Producer, SendAsync)
 {
-    Connector connector = makeProducerConnector(asyncConfig, topicWithHeaders());
+    Connector connector = makeProducerConnector(asyncConfig, producerTopicConfig, topicWithHeaders());
     
     std::vector<quantum::GenericFuture<DeliveryReport>> futures;
     //Send messages
@@ -277,7 +282,7 @@ TEST(Producer, SendAsync)
 
 TEST(Producer, SendAsyncUnordered)
 {
-    Connector connector = makeProducerConnector(asyncUnorderedConfig, topicWithHeaders());
+    Connector connector = makeProducerConnector(asyncUnorderedConfig, producerTopicConfig, topicWithHeaders());
     
     std::vector<quantum::GenericFuture<DeliveryReport>> futures;
     //Send messages

--- a/tests/corokafka_tests_3_consumer.cpp
+++ b/tests/corokafka_tests_3_consumer.cpp
@@ -15,6 +15,11 @@ std::string getNewGroupName()
     return "group_" + std::to_string(i++);
 }
 
+//topic config
+Configuration::OptionList consumerTopicConfig = {
+    {TopicConfiguration::Options::brokerTimeoutMs, 5000}
+};
+
 //paused on start with auto commit every 10ms
 Configuration::OptionList config1 = {
     {"enable.partition.eof", true},
@@ -341,6 +346,7 @@ TEST(Consumer, ValidatePauseOnStart)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
         config1,
+        consumerTopicConfig,
         getNewGroupName(),
         topicWithoutHeaders(),
         Callbacks::messageReceiverWithoutHeaders,
@@ -381,6 +387,7 @@ TEST(Consumer, ReadTopicWithoutHeadersUsingConfig1)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
         config1,
+        consumerTopicConfig,
         getNewGroupName(),
         topicWithoutHeaders(),
         Callbacks::messageReceiverWithoutHeaders,
@@ -426,6 +433,7 @@ TEST(Consumer, ReadTopicWithHeadersUsingConfig2)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
         config2,
+        consumerTopicConfig,
         getNewGroupName(),
         topicWithHeaders(),
         Callbacks::messageReceiverWithHeadersManualCommit,
@@ -465,6 +473,7 @@ TEST(Consumer, ReadTopicWithHeadersUsingConfig3)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
         config3,
+        consumerTopicConfig,
         getNewGroupName(),
         topicWithHeaders(),
         Callbacks::messageReceiverWithHeadersManualCommit,
@@ -504,6 +513,7 @@ TEST(Consumer, ReadTopicWithHeadersUsingConfig4)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
         config4,
+        consumerTopicConfig,
         getNewGroupName(),
         topicWithHeaders(),
         Callbacks::messageReceiverWithHeadersManualCommit,
@@ -551,6 +561,7 @@ TEST(Consumer, SkipMessagesWithRelativeOffsetUsingConfig2)
     
     Connector connector = makeConsumerConnector(
         config2,
+        consumerTopicConfig,
         getNewGroupName(),
         topicWithHeaders(),
         Callbacks::messageReceiverWithHeadersManualCommit,
@@ -579,6 +590,7 @@ TEST(Consumer, OffsetCommitManagerFromBeginning)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
             config4,
+            consumerTopicConfig,
             getNewGroupName(),
             topicWithHeaders(),
             Callbacks::messageReceiverWithHeadersUsingCommitGuard,
@@ -619,6 +631,7 @@ TEST(Consumer, OffsetCommitManagerRelative)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
             config4,
+            consumerTopicConfig,
             getNewGroupName(),
             topicWithHeaders(),
             Callbacks::messageReceiverWithHeadersUsingCommitGuard,
@@ -668,6 +681,7 @@ TEST(Consumer, OffsetCommitManagerFromStored)
         
         Connector connector = makeConsumerConnector(
                 config4,
+                consumerTopicConfig,
                 consumerGroup,
                 topicWithHeaders(),
                 Callbacks::messageReceiverWithHeadersUsingCommitGuard,
@@ -710,6 +724,7 @@ TEST(Consumer, OffsetCommitManagerFromStored)
         
         Connector connector = makeConsumerConnector(
                 config4,
+                consumerTopicConfig,
                 consumerGroup,
                 topicWithHeaders(),
                 Callbacks::messageReceiverWithHeadersUsingCommitGuard,
@@ -753,6 +768,7 @@ TEST(Consumer, ValidateDynamicAssignment)
     callbackCounters().reset();
     Connector connector = makeConsumerConnector(
         config1,
+        consumerTopicConfig,
         groupName,
         topicWithoutHeaders(),
         Callbacks::messageReceiverWithoutHeaders,
@@ -770,6 +786,7 @@ TEST(Consumer, ValidateDynamicAssignment)
     //Create a 2nd connector for the same group
     Connector connector2 = makeConsumerConnector(
         config1,
+        consumerTopicConfig,
         groupName,
         topicWithoutHeaders(),
         Callbacks::messageReceiverWithoutHeaders,

--- a/tests/corokafka_tests_utils.h
+++ b/tests/corokafka_tests_utils.h
@@ -294,11 +294,13 @@ void testConsumerOption(const char* exName, const char* opName, const ValueTestL
 }
 
 template <typename TOPIC>
-Connector makeProducerConnector(const Configuration::OptionList& ops, const TOPIC& topic)
+Connector makeProducerConnector(const Configuration::OptionList& ops,
+                                const Configuration::OptionList& topicOps,
+                                const TOPIC& topic)
 {
     Configuration::OptionList options = ops;
     options.push_back({"metadata.broker.list", programOptions()._broker});
-    ProducerConfiguration config(topic, options, {});
+    ProducerConfiguration config(topic, options, topicOps);
     config.setPartitionerCallback(Callbacks::partitioner);
     ConfigurationBuilder builder;
     ConnectorConfiguration connConfig({
@@ -310,6 +312,7 @@ Connector makeProducerConnector(const Configuration::OptionList& ops, const TOPI
 
 template <typename TOPIC, typename RECV>
 Connector makeConsumerConnector(const Configuration::OptionList& ops,
+                                const Configuration::OptionList& topicOps,
                                 const std::string& groupId,
                                 TOPIC&& topic,
                                 RECV&& receiver,
@@ -319,7 +322,7 @@ Connector makeConsumerConnector(const Configuration::OptionList& ops,
     Configuration::OptionList options = ops;
     options.push_back({"metadata.broker.list", programOptions()._broker});
     options.push_back({"group.id", groupId});
-    ConsumerConfiguration config(std::forward<TOPIC>(topic), options, {}, std::forward<RECV>(receiver));
+    ConsumerConfiguration config(std::forward<TOPIC>(topic), options, topicOps, std::forward<RECV>(receiver));
     config.setPreprocessorCallback(Callbacks::messagePreprocessor);
     config.setOffsetCommitCallback(Callbacks::handleOffsetCommit);
     config.setRebalanceCallback(Callbacks::handleRebalance);


### PR DESCRIPTION
**Description**
- Added broker timeout for metadata operations. This allows for a finer timeout control over metadata queries to the brokers. By default this value is initialized with the consumer or producer generic timeout value.
- Fixed issue with setting an expired future if producing a message failed to enqueue. 

Signed-off-by: Alexander Damian <adamian@bloomberg.net>fix
