### PR TITLE
Fixed extraction of values from topic_options

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -24,7 +24,7 @@ The following configuration options are complementary to the RdKafka [options](h
 | internal.consumer.auto.offset.persist | true, false | true | Enables auto-commit/auto-store inside the `ReceivedMessage` destructor. |
 | internal.consumer.auto.offset.persist.on.exception | true, false | false | Dictates if the offset persist should be aborted as a result of an exception. This could allow the application to reprocess a message following an exception. This is only valid if **internal.consumer.auto.offset.persist=true**. |
 | internal.consumer.offset.persist.strategy | commit, store | store | Determines if offsets are committed or stored locally. Some RdKafka settings will be changed according to **note 2** below. If **store** is chosen, **auto.commit.interval.ms > 0** must be set. Note that the **store** option is only valid for RdKafka versions >= **0.9.5.1** |
-| internal.consumer.commit.exec | sync, async | async | Dictates if offset commits should be synchronous or asynchronous. |
+| internal.consumer.commit.exec | sync, async | async | Dictates if offset commits should be synchronous or asynchronous. This setting only applies if **internal.consumer.offset.persist.strategy=commit**. |
 | internal.consumer.commit.num.retries | \>= 0 | MAX_UINT | Sets the number of times to retry committing an offset before giving up. |
 | internal.consumer.commit.backoff.strategy | linear, exponential | linear | Back-off strategy when initial commit fails. |
 | internal.consumer.commit.backoff.interval.ms | \> 0 | 100 | Time in ms between retries. |

--- a/corokafka/impl/corokafka_producer_manager_impl.cpp
+++ b/corokafka/impl/corokafka_producer_manager_impl.cpp
@@ -122,7 +122,11 @@ void ProducerManagerImpl::setup(const std::string& topic, ProducerTopicEntry& to
     
     auto extract = [&](const std::string &name, auto &value) -> bool
     {
-        return ProducerConfiguration::extract(name)(topic, topicEntry._configuration.getOption(name), &value);
+        const cppkafka::ConfigurationOption* op = topicEntry._configuration.getOption(name);
+        if (!op) {
+            op = topicEntry._configuration.getTopicOption(name);
+        }
+        return ProducerConfiguration::extract(name)(topic, op, &value);
     };
     
     //Validate config

--- a/tests/corokafka_tests_3_consumer.cpp
+++ b/tests/corokafka_tests_3_consumer.cpp
@@ -24,7 +24,7 @@ Configuration::OptionList consumerTopicConfig = {
 Configuration::OptionList config1 = {
     {"enable.partition.eof", true},
     {"enable.auto.offset.store", false},
-    {"enable.auto.commit", true},
+    {"enable.auto.commit", false},
     {"auto.offset.reset","beginning"},
     {"auto.commit.interval.ms", 10},
     //{"debug","all"},


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>
- Fixed extraction of topic option values when building consumers and producers
- Removed OR condition for synchronous commits when `store` method is used