### PR TITLE
Read auto.offset.reset from topic options as well inside OffsetManager

### DIFF
--- a/corokafka/utils/corokafka_offset_manager.cpp
+++ b/corokafka/utils/corokafka_offset_manager.cpp
@@ -48,6 +48,9 @@ OffsetManager::OffsetManager(corokafka::ConsumerManager& consumerManager,
         const ConsumerConfiguration& config = _consumerManager.getConfiguration(topic);
         //Check the offset reset if specified
         const cppkafka::ConfigurationOption* offsetReset = config.getOption("auto.offset.reset");
+        if (!offsetReset) {
+            offsetReset = config.getTopicOption("auto.offset.reset");
+        }
         if (offsetReset && StringEqualCompare()(offsetReset->get_value(), "smallest")) {
             topicSettings._autoResetAtEnd = false;
         }


### PR DESCRIPTION
**Description**
Read auto.offset.reset from topic options as well inside OffsetManager

**Additional context**
In latest RdKafka versions, the `auto.offset.reset` option can be set from either topic or global scope. But in older version it's only valid if set in topic scope. This change allows for dual support.
