### PR TITLE
Specify the log severity level when outputting commit messages in the…

### DIFF
--- a/corokafka/corokafka_configuration.cpp
+++ b/corokafka/corokafka_configuration.cpp
@@ -151,7 +151,6 @@ const std::string& Configuration::getJsonSchema()
                 "required": ["name","config"]
             }
         },
-
         "title": "Kafka connector settings",
         "type": "object",
         "properties": {

--- a/corokafka/impl/corokafka_offset_manager_impl.cpp
+++ b/corokafka/impl/corokafka_offset_manager_impl.cpp
@@ -376,9 +376,13 @@ std::string OffsetManagerImpl::toString(const std::string& topic) const
     return oss.str();
 }
 
-void OffsetManagerImpl::enableCommitTracing(bool enable)
+void OffsetManagerImpl::enableCommitTracing(bool enable,
+                                            cppkafka::LogLevel level)
 {
     _traceCommits = enable;
+    if (enable) {
+        _commitLogLevel = level;
+    }
 }
 
 void OffsetManagerImpl::logOffsets(const std::string& facility,
@@ -392,7 +396,7 @@ void OffsetManagerImpl::logOffsets(const std::string& facility,
     std::ostringstream oss;
     oss << offset;
     logCallback(_consumerManager.getMetadata(topic),
-                cppkafka::LogLevel::LogDebug,
+                _commitLogLevel,
                 facility,
                 oss.str());
 }
@@ -408,7 +412,7 @@ void OffsetManagerImpl::logOffsets(const std::string& facility,
     std::ostringstream oss;
     oss << offsets;
     logCallback(_consumerManager.getMetadata(topic),
-                cppkafka::LogLevel::LogDebug,
+                _commitLogLevel,
                 facility,
                 oss.str());
 }

--- a/corokafka/impl/corokafka_offset_manager_impl.h
+++ b/corokafka/impl/corokafka_offset_manager_impl.h
@@ -63,7 +63,8 @@ public:
                                ResetAction action) override;
     std::string toString() const override;
     std::string toString(const std::string& topic) const override;
-    void enableCommitTracing(bool enable) override;
+    void enableCommitTracing(bool enable,
+                             cppkafka::LogLevel level) override;
     
 private:
     using OffsetMap = IntervalSet<int64_t>;
@@ -132,6 +133,7 @@ private:
     std::chrono::milliseconds       _brokerTimeout;
     TopicMap                        _topicMap;
     bool                            _traceCommits{false};
+    cppkafka::LogLevel              _commitLogLevel{cppkafka::LogLevel::LogDebug};
 };
 
 // Implementation

--- a/corokafka/interface/corokafka_ioffset_manager.h
+++ b/corokafka/interface/corokafka_ioffset_manager.h
@@ -43,7 +43,8 @@ struct IOffsetManager
                                        ResetAction action) = 0;
     virtual std::string toString() const = 0;
     virtual std::string toString(const std::string& topic) const = 0;
-    virtual void enableCommitTracing(bool enable) = 0;
+    virtual void enableCommitTracing(bool enable,
+                                     cppkafka::LogLevel) = 0;
 };
 
 }}

--- a/corokafka/mock/corokafka_offset_manager_mock.h
+++ b/corokafka/mock/corokafka_offset_manager_mock.h
@@ -28,7 +28,7 @@ struct OffsetManagerMock : public IOffsetManager
     MOCK_METHOD2(resetPartitionOffsets, void(const std::string&, ResetAction));
     MOCK_CONST_METHOD0(toString, std::string());
     MOCK_CONST_METHOD1(toString, std::string(const std::string&));
-    MOCK_METHOD1(enableCommitTracing, void(bool));
+    MOCK_METHOD2(enableCommitTracing, void(bool, cppkafka::LogLevel));
 };
 
 }}}

--- a/corokafka/utils/corokafka_offset_manager.cpp
+++ b/corokafka/utils/corokafka_offset_manager.cpp
@@ -132,9 +132,10 @@ std::string OffsetManager::toString(const std::string& topic) const
     return impl()->toString(topic);
 }
 
-void OffsetManager::enableCommitTracing(bool enable)
+void OffsetManager::enableCommitTracing(bool enable,
+                                        cppkafka::LogLevel level)
 {
-    impl()->enableCommitTracing(enable);
+    impl()->enableCommitTracing(enable, level);
 }
 
 std::ostream& operator<<(std::ostream& output, const OffsetManager& rhs)

--- a/corokafka/utils/corokafka_offset_manager.h
+++ b/corokafka/utils/corokafka_offset_manager.h
@@ -108,18 +108,19 @@ public:
     void resetPartitionOffsets(const std::string& topic,
                                ResetAction action = ResetAction::FetchOffsets) override;
     
-    /// @brief Output the offsets contained by this manager
-    /// @param topic Restrict output to a specific topic only
+    /// @brief Output the offsets contained by this manager.
+    /// @param topic Restrict output to a specific topic only.
     std::string toString() const override;
     std::string toString(const std::string& topic) const override;
     
-    /// @brief Enables or disables commit debug logging via the registered
-    ///        log callback in the ConsumerManager
+    /// @brief Enables or disables commit logging via the registered
+    ///        log callback in the ConsumerManager at the specified severity level.
     /// @warning May be verbose
-    void enableCommitTracing(bool enable) override;
+    void enableCommitTracing(bool enable,
+                             cppkafka::LogLevel level = cppkafka::LogLevel::LogDebug) override;
     
     /**
-     * @brief For mocking only via dependency injection
+     * @brief For mocking only via dependency injection.
      */
     using ImplType = Impl<IOffsetManager>;
     using ImplType::ImplType;


### PR DESCRIPTION
Specify the log severity level when outputting commit messages in the `OffsetManager`.

Signed-off-by: Alexander Damian <adamian@bloomberg.net>
