### PR TITLE
Split enableCommitTracing() into two separate overloads

### DIFF
--- a/corokafka/impl/corokafka_offset_manager_impl.cpp
+++ b/corokafka/impl/corokafka_offset_manager_impl.cpp
@@ -376,6 +376,11 @@ std::string OffsetManagerImpl::toString(const std::string& topic) const
     return oss.str();
 }
 
+void OffsetManagerImpl::enableCommitTracing(bool enable)
+{
+    _traceCommits = enable;
+}
+
 void OffsetManagerImpl::enableCommitTracing(bool enable,
                                             cppkafka::LogLevel level)
 {

--- a/corokafka/impl/corokafka_offset_manager_impl.h
+++ b/corokafka/impl/corokafka_offset_manager_impl.h
@@ -63,6 +63,7 @@ public:
                                ResetAction action) override;
     std::string toString() const override;
     std::string toString(const std::string& topic) const override;
+    void enableCommitTracing(bool enable) override;
     void enableCommitTracing(bool enable,
                              cppkafka::LogLevel level) override;
     

--- a/corokafka/interface/corokafka_ioffset_manager.h
+++ b/corokafka/interface/corokafka_ioffset_manager.h
@@ -43,6 +43,7 @@ struct IOffsetManager
                                        ResetAction action) = 0;
     virtual std::string toString() const = 0;
     virtual std::string toString(const std::string& topic) const = 0;
+    virtual void enableCommitTracing(bool enable) = 0;
     virtual void enableCommitTracing(bool enable,
                                      cppkafka::LogLevel) = 0;
 };

--- a/corokafka/mock/corokafka_offset_manager_mock.h
+++ b/corokafka/mock/corokafka_offset_manager_mock.h
@@ -28,6 +28,7 @@ struct OffsetManagerMock : public IOffsetManager
     MOCK_METHOD2(resetPartitionOffsets, void(const std::string&, ResetAction));
     MOCK_CONST_METHOD0(toString, std::string());
     MOCK_CONST_METHOD1(toString, std::string(const std::string&));
+    MOCK_METHOD1(enableCommitTracing, void(bool));
     MOCK_METHOD2(enableCommitTracing, void(bool, cppkafka::LogLevel));
 };
 

--- a/corokafka/utils/corokafka_offset_manager.cpp
+++ b/corokafka/utils/corokafka_offset_manager.cpp
@@ -132,6 +132,11 @@ std::string OffsetManager::toString(const std::string& topic) const
     return impl()->toString(topic);
 }
 
+void OffsetManager::enableCommitTracing(bool enable)
+{
+    impl()->enableCommitTracing(enable);
+}
+
 void OffsetManager::enableCommitTracing(bool enable,
                                         cppkafka::LogLevel level)
 {

--- a/corokafka/utils/corokafka_offset_manager.h
+++ b/corokafka/utils/corokafka_offset_manager.h
@@ -114,10 +114,13 @@ public:
     std::string toString(const std::string& topic) const override;
     
     /// @brief Enables or disables commit logging via the registered
-    ///        log callback in the ConsumerManager at the specified severity level.
+    ///        log callback in the ConsumerManager
+    /// @param enable True to enable logging and False to disable.
+    /// @param level The logging severity level. If not specified, the level defaults to Debug.
     /// @warning May be verbose
+    void enableCommitTracing(bool enable) override;
     void enableCommitTracing(bool enable,
-                             cppkafka::LogLevel level = cppkafka::LogLevel::LogDebug) override;
+                             cppkafka::LogLevel level) override;
     
     /**
      * @brief For mocking only via dependency injection.


### PR DESCRIPTION
Signed-off-by: Alexander Damian <adamian@bloomberg.net>
