### PR TITLE
Demonstrate race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,4 +96,4 @@ script:
         -DCMAKE_BUILD_TYPE=Debug
         -G Ninja -S .
   - ninja CoroKafkaTests
-  - travis_wait 30 $EXEC -b localhost:9092 -k producer -t topic_with_headers -n topic_no_headers
+  - $EXEC -b localhost:9092 -k producer -t topic_with_headers -n topic_no_headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
   - sudo sysctl -w kernel.core_pattern=$TRAVIS_BUILD_DIR/cores/core.%e.%p
   - cat /proc/sys/kernel/core_pattern
   - service --status-all || true
-  - KAFKA_REL=2.6.1  
+  - KAFKA_REL=2.8.1  
   - KAFKA_VERSION=2.12-$KAFKA_REL
   - RD_KAFKA_VERSION=v1.6.0
   - wget http://apache.cs.utah.edu/kafka/$KAFKA_REL/kafka_$KAFKA_VERSION.tgz && tar -xvzf kafka_$KAFKA_VERSION.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,4 +96,4 @@ script:
         -DCMAKE_BUILD_TYPE=Debug
         -G Ninja -S .
   - ninja CoroKafkaTests
-  - $EXEC -b localhost:9092 -k producer -t topic_with_headers -n topic_no_headers
+  - travis_wait 30 $EXEC -b localhost:9092 -k producer -t topic_with_headers -n topic_no_headers

--- a/tests/corokafka_tests_4_dispatcher.cpp
+++ b/tests/corokafka_tests_4_dispatcher.cpp
@@ -1,15 +1,20 @@
 #include <corokafka_tests_callbacks.h>
 #include <gtest/gtest.h>
 
-namespace Bloomberg {
-namespace corokafka {
-namespace tests {
-
-TEST(Quantum, Drain)
+namespace Bloomberg::corokafka::tests
 {
-    //This test must run last
-    dispatcher().drain();
-    dispatcher().terminate();
-}
 
-}}}
+class QuantumEnvironment : public ::testing::Environment
+{
+    public:
+        ~QuantumEnvironment() override{};
+
+        void TearDown() override { dispatcher().drain();
+            dispatcher().terminate();
+        }
+};  // class QuantumEnvironment
+
+::testing::Environment* const quantumEnvironment =
+        testing::AddGlobalTestEnvironment(new QuantumEnvironment);
+
+}    // namespace Bloomberg::corokafka::tests

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -429,7 +429,7 @@ public:
             { "client.id", "offset-manager-consumer" },
             { "group.id", "offset-manager-group" },
             { "enable.auto.offset.store", false },
-            { "enable.partition.eof", false },
+            //{ "enable.partition.eof", false },
             { "enable.auto.commit", true },
             { ConsumerConfiguration::Options::timeoutMs, 100 },
             { ConsumerConfiguration::Options::pauseOnStart, false },
@@ -470,9 +470,6 @@ public:
         producerConfig.setPartitionerCallback(partition0Callback);
         builder(producerConfig);
         d_connector = std::make_unique<Connector>(builder, dispatcher());
-        // Wait for connector to get connected
-        using namespace std::chrono_literals;
-        std::this_thread::sleep_for(5s);
 
         auto topicList = d_connector->consumer().getTopics();
         for (const auto& topic : topicList)
@@ -483,12 +480,14 @@ public:
         }
 
         // Create OffsetManager
+        using namespace std::chrono_literals;
         d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer(), -1ms);
     }
 
     ~OffsetManagerTester() { d_connector->shutdown(); }
 
-    void produce(const unsigned int numMessages) {
+    void produce(const unsigned int numMessages)
+    {
         Key     key{ 0 };
         Message payload;
         payload._message = { "test message" };
@@ -638,7 +637,7 @@ TEST(OffsetManager, SaveOffsetRace)
 
     for (unsigned int i = 0; i < numTests; ++i)
     {
-        tester.verifyRaceCondition(2);
+        //tester.verifyRaceCondition(2);
     }
 }
 

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -423,14 +423,6 @@ public:
         return {};
     }
 
-    cppkafka::Error commit(const cppkafka::TopicPartition& topicPartition,
-                           ExecMode                        execMode,
-                           const void*                     opaque) override
-    {
-        std::cout << "commit() with ExecMode called" << std::endl;
-        return {};
-    }
-
     int64_t getLastOffset()
     {
         quantum::Mutex::Guard guard{ quantum::local::context(), d_mutex };
@@ -450,7 +442,8 @@ TEST(OffsetManager, SaveOffsetRace)
                                                                 Configuration::OptionList{});
     // Expectations
     auto& metadataMock = consumerManagerMock.consumerMetadataMock();
-    EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(Committed));
+    const cppkafka::TopicPartitionList committedOffsets{ {  TopicName, 0, -1  } };
+    EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(committedOffsets));
     EXPECT_CALL(metadataMock, queryOffsetWatermarks()).WillOnce(Return(Watermarks));
     EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(StoredAssignment));
 

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -474,7 +474,7 @@ public:
 
         // Wait for connector to get connected
         using namespace std::chrono_literals;
-        std::this_thread::sleep_for(5s);
+        std::this_thread::sleep_for(10s);
 
         // Create OffsetManager
         d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer());

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -410,7 +410,6 @@ class OffsetManagerTester
 public:
     OffsetManagerTester()
     {
-        std::cout << "OffsetManagerTester(): starting" << std::endl;
         using std::placeholders::_1;
         using std::placeholders::_2;
         using std::placeholders::_3;
@@ -470,22 +469,18 @@ public:
                                               topicOptions };
         producerConfig.setPartitionerCallback(partition0Callback);
         builder(producerConfig);
-        std::cout << "OffsetManagerTester(): config completed" << std::endl;
         d_connector = std::make_unique<Connector>(builder, dispatcher());
-        std::cout << "OffsetManagerTester(): connector created" << std::endl;
         // Wait for connector to get connected
         using namespace std::chrono_literals;
         std::this_thread::sleep_for(5s);
 
         // Create OffsetManager
         d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer(), -1ms);
-        std::cout << "OffsetManagerTester(): offsetManager created" << std::endl;
     }
 
     ~OffsetManagerTester() { d_connector->shutdown(); }
 
     void produce(const unsigned int numMessages) {
-        std::cout << "OffsetManagerTester::produce(): producing " << numMessages << std::endl;
         Key     key{ 0 };
         Message payload;
         payload._message = { "test message" };
@@ -494,7 +489,6 @@ public:
             payload._num = i;
             d_connector->producer().send(topicWithoutHeaders(), nullptr, key, payload);
         }
-        std::cout << "OffsetManagerTester::produce(): done" << std::endl;
     }
 
     void verifyRaceCondition(const unsigned int numOffsets)
@@ -563,6 +557,7 @@ private:
         {
             return;
         }
+        std::cout << "Received a message with offset " << received.getOffset() << std::endl;
         quantum::Mutex::Guard guard{ quantum::local::context(), d_offsetsMutex };
         d_offsets.emplace_back(cppkafka::TopicPartition{
                 received.getTopic(), received.getPartition(), received.getOffset() });

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -443,7 +443,6 @@ public:
             { ConsumerConfiguration::Options::receiveCallbackThreadRangeLow, 1 },
             { ConsumerConfiguration::Options::receiveCallbackThreadRangeHigh, 1 },
             { ConsumerConfiguration::Options::preserveMessageOrder, true },
-            { ConsumerConfiguration::Options::timeoutMs, "20000" }
         };
         ConsumerConfiguration consumerConfig{
             topicWithoutHeaders(),
@@ -477,7 +476,7 @@ public:
         std::this_thread::sleep_for(5s);
 
         // Create OffsetManager
-        d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer());
+        d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer(), -1ms);
     }
 
     ~OffsetManagerTester() { d_connector->shutdown(); }

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -410,6 +410,7 @@ class OffsetManagerTester
 public:
     OffsetManagerTester()
     {
+        std::cout << "OffsetManagerTester(): starting" << std::endl;
         using std::placeholders::_1;
         using std::placeholders::_2;
         using std::placeholders::_3;
@@ -468,21 +469,23 @@ public:
                                               topicOptions };
         producerConfig.setPartitionerCallback(partition0Callback);
         builder(producerConfig);
-
+        std::cout << "OffsetManagerTester(): config completed" << std::endl;
         d_connector = std::make_unique<Connector>(builder, dispatcher());
-
+        std::cout << "OffsetManagerTester(): connector created" << std::endl;
         // Wait for connector to get connected
         using namespace std::chrono_literals;
         std::this_thread::sleep_for(5s);
 
         // Create OffsetManager
         d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer(), -1ms);
+        std::cout << "OffsetManagerTester(): offsetManager created" << std::endl;
     }
 
     ~OffsetManagerTester() { d_connector->shutdown(); }
 
     void produce(const unsigned int numMessages) {
-        Key key{ 0 };
+        std::cout << "OffsetManagerTester::produce(): producing " << numMessages << std::endl;
+        Key     key{ 0 };
         Message payload;
         payload._message = { "test message" };
         for (unsigned int i = 0; i < numMessages; ++i)
@@ -490,6 +493,7 @@ public:
             payload._num = i;
             d_connector->producer().send(topicWithoutHeaders(), nullptr, key, payload);
         }
+        std::cout << "OffsetManagerTester::produce(): done" << std::endl;
     }
 
     void verifyRaceCondition(const unsigned int numOffsets)

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -452,8 +452,6 @@ TEST(OffsetManager, SaveOffsetRace)
     EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(BeginningAssignment));
 
     OffsetManagerTestAdapter offsetManager(consumerManagerMock);
-    offsetManager.resetPartitionOffsets(TopicName,
-                                        OffsetManagerImpl::ResetAction::DoNotFetchOffsets);
 
     unsigned int numTests = 10;
 

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -416,8 +416,17 @@ public:
         }
 
         quantum::Mutex::Guard guard{ ctx, d_mutex };
+        std::cout << "Going to record commit() " << topicPartitions[0] << std::endl;
         d_committed = topicPartitions[0];
 
+        return {};
+    }
+
+    cppkafka::Error commit(const cppkafka::TopicPartitionList& topicPartitions,
+                           ExecMode                            execMode,
+                           const void*                         opaque) override
+    {
+        std::cout << "commit() with ExecMode called" << std::endl;
         return {};
     }
 

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -443,7 +443,7 @@ public:
             { ConsumerConfiguration::Options::receiveCallbackThreadRangeLow, 1 },
             { ConsumerConfiguration::Options::receiveCallbackThreadRangeHigh, 1 },
             { ConsumerConfiguration::Options::preserveMessageOrder, true },
-            { ConsumerConfiguration::Options::timeoutMs, "5000" }
+            { ConsumerConfiguration::Options::timeoutMs, "20000" }
         };
         ConsumerConfiguration consumerConfig{
             topicWithoutHeaders(),
@@ -474,7 +474,7 @@ public:
 
         // Wait for connector to get connected
         using namespace std::chrono_literals;
-        std::this_thread::sleep_for(10s);
+        std::this_thread::sleep_for(5s);
 
         // Create OffsetManager
         d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer());

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -442,11 +442,7 @@ TEST(OffsetManager, SaveOffsetRace)
                                                                 Configuration::OptionList{});
     // Expectations
     auto& metadataMock = consumerManagerMock.consumerMetadataMock();
-    const OffsetWatermarkList watermarks{
-        { Partition,
-          { cppkafka::TopicPartition::Offset::OFFSET_INVALID,
-            cppkafka::TopicPartition::Offset::OFFSET_INVALID } }
-    };
+    const OffsetWatermarkList watermarks{ { Partition, { -1, -1 } } };
     EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(CommittedInvalid));
     EXPECT_CALL(metadataMock, queryOffsetWatermarks()).WillOnce(Return(watermarks));
     EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(BeginningAssignment));

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -1,15 +1,9 @@
 #include <corokafka/impl/corokafka_offset_manager_impl.h>
 #include <corokafka/mock/corokafka_consumer_manager_mock.h>
 
-#include <corokafka/corokafka_connector.h>
-#include <corokafka/utils/corokafka_offset_manager.h>
 #include <corokafka_tests_utils.h>
 
-#include <cppkafka/topic_partition_list.h>
-
-#include <chrono>
-#include <functional>
-#include <memory>
+#include <quantum/quantum_mutex.h>
 
 using testing::_;
 using testing::Return;
@@ -398,130 +392,75 @@ TEST(OffsetManager, ResetPartitionNoFetch)
     EXPECT_THROW(offsetManager.getCurrentOffset(QueryPartition), std::out_of_range);
 }
 
-static int32_t partition0Callback(const ProducerMetadata &metadata,
-                               const cppkafka::Buffer &key,
-                               int32_t partitionCount)
-{
-    return 0;
-}
-
-class OffsetManagerTester
+class ConsumerManagerOffsetRaceFake : public mocks::ConsumerManagerMock
 {
 public:
-    OffsetManagerTester()
+    template<typename TOPIC>
+    ConsumerManagerOffsetRaceFake(const TOPIC&              topic,
+                                  Configuration::OptionList options,
+                                  Configuration::OptionList topicOptions)
+        : mocks::ConsumerManagerMock{ topic, options, topicOptions }
+    {}
+    // Fake commit() - trust that topicPartitions is always size=1 for these tests
+    cppkafka::Error commit(const cppkafka::TopicPartitionList& topicPartitions,
+                           const void*                         opaque) override
     {
-        using std::placeholders::_1;
-        using std::placeholders::_2;
-        using std::placeholders::_3;
-        using std::placeholders::_4;
-
-        ConfigurationBuilder builder;
-        // Connector configuration
-        ConnectorConfiguration connConfig(
-                { { ConnectorConfiguration::Options::pollIntervalMs, 10 } });
-        builder(connConfig);
-
-        Configuration::OptionList topicOptions{ { TopicConfiguration::Options::brokerTimeoutMs,
-                                                 5000 } };
-        // Consumer configuration
-        Configuration::OptionList consumerOptions{
-            { "metadata.broker.list", programOptions()._broker },
-            { "client.id", "offset-manager-consumer" },
-            { "group.id", "offset-manager-group" },
-            { "enable.auto.offset.store", false },
-            //{ "enable.partition.eof", false },
-            { "enable.auto.commit", true },
-            { ConsumerConfiguration::Options::timeoutMs, 100 },
-            { ConsumerConfiguration::Options::pauseOnStart, false },
-            { ConsumerConfiguration::Options::readSize, 100 },
-            { ConsumerConfiguration::Options::pollStrategy, "batch" },
-            { ConsumerConfiguration::Options::offsetPersistStrategy, "store" },
-            { ConsumerConfiguration::Options::commitExec, "sync" },
-            { ConsumerConfiguration::Options::autoOffsetPersist, "true" },
-            { ConsumerConfiguration::Options::receiveInvokeThread, "coro" },
-            { ConsumerConfiguration::Options::preprocessMessages, "false" },
-            { ConsumerConfiguration::Options::receiveCallbackThreadRangeLow, 1 },
-            { ConsumerConfiguration::Options::receiveCallbackThreadRangeHigh, 1 },
-            { ConsumerConfiguration::Options::preserveMessageOrder, true },
-        };
-        ConsumerConfiguration consumerConfig{
-            topicWithoutHeaders(),
-            consumerOptions,
-            topicOptions,
-            std::bind(&OffsetManagerTester::receiveCallback, this, _1)
-        };
-        consumerConfig.setOffsetCommitCallback(
-                std::bind(&OffsetManagerTester::offsetCommitCallback, this, _1, _2, _3, _4));
-        consumerConfig.setLogCallback(std::bind(&OffsetManagerTester::logCallback, this, _1, _2, _3, _4));
-        consumerConfig.assignInitialPartitions(
-                PartitionStrategy::Static,
-                { { topicWithoutHeaders().topic(), 0, (int) OffsetPoint::AtEnd } });
-
-        builder(consumerConfig);
-        // Producer configuration
-        Configuration::OptionList producerOptions{
-            { "metadata.broker.list", programOptions()._broker },
-            { "client.id", "offset-manager-producer" },
-            { "enable.idempotence", true },
-        };
-        ProducerConfiguration producerConfig{ topicWithoutHeaders(),
-                                              producerOptions,
-                                              topicOptions };
-        producerConfig.setPartitionerCallback(partition0Callback);
-        builder(producerConfig);
-        d_connector = std::make_unique<Connector>(builder, dispatcher());
-
-        auto topicList = d_connector->consumer().getTopics();
-        for (const auto& topic : topicList)
+        auto ctx = quantum::local::context();
+        // yield if offset is even - to increase the odds of the race condition
+        if (topicPartitions[0].get_offset() % 2 == 0)
         {
-            std::cout << "Consuming " << topic << std::endl;
-            auto metadata = d_connector->consumer().getMetadata(topic);
-            std::cout << "partitions " << metadata.getPartitionAssignment() << std::endl;
+            if (ctx)
+            {
+                ctx->yield();
+            }
         }
 
-        // Create OffsetManager
-        using namespace std::chrono_literals;
-        d_offsetManager = std::make_unique<OffsetManager>(d_connector->consumer(), -1ms);
+        quantum::Mutex::Guard guard{ ctx, d_mutex };
+        d_committed = topicPartitions[0];
+
+        return {};
     }
 
-    ~OffsetManagerTester() { d_connector->shutdown(); }
-
-    void produce(const unsigned int numMessages)
+    int64_t getLastOffset()
     {
-        Key     key{ 0 };
-        Message payload;
-        payload._message = { "test message" };
-        for (unsigned int i = 0; i < numMessages; ++i)
-        {
-            payload._num = i;
-            auto dr = d_connector->producer().send(topicWithoutHeaders(), nullptr, key, payload);
-            std::cout << "OffsetManagerTester::produce() dr=" << dr << std::endl;
-        }
+        quantum::Mutex::Guard guard{ quantum::local::context(), d_mutex };
+        return d_committed.get_offset();
     }
 
-    void verifyRaceCondition(const unsigned int numOffsets)
+private:
+    quantum::Mutex           d_mutex;
+    cppkafka::TopicPartition d_committed;
+
+};    // ConsumerManagerOffsetRaceFake
+
+TEST(OffsetManager, SaveOffsetRace)
+{
+    NiceMock<ConsumerManagerOffsetRaceFake> consumerManagerMock(mocks::MockTopic{ TopicName },
+                                                                Configuration::OptionList{},
+                                                                Configuration::OptionList{});
+    // Expectations
+    auto& metadataMock = consumerManagerMock.consumerMetadataMock();
+    EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(Committed));
+    EXPECT_CALL(metadataMock, queryOffsetWatermarks()).WillOnce(Return(Watermarks));
+    EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(StoredAssignment));
+
+    OffsetManagerTestAdapter offsetManager(consumerManagerMock);
+
+    unsigned int numTests = 10;
+
+    for (unsigned int i = 0; i < numTests; ++i)
     {
-        auto offsets = extractOffsets(numOffsets);
-        if (offsets.empty())
-        {
-            // This will fail and cause the test to fail
-            EXPECT_EQ(numOffsets, d_offsets.size());
-            return;
-        }
-
-        {
-            quantum::Mutex::Guard guard{ quantum::local::context(), d_offsetsMutex };
-            d_lastCommitted = std::nullopt;
-        }
-
+        unsigned int                 low  = i * 2;
+        unsigned int                 high = low + 1;
+        cppkafka::TopicPartitionList offsets{ { TopicName, 0, low }, { TopicName, 0, high } };
         std::vector<Bloomberg::quantum::ThreadContext<int>::Ptr> futures;
         for (const auto& offset : offsets)
         {
             futures.emplace_back(dispatcher().post2(
-                    [this](Bloomberg::quantum::CoroContext<int>::Ptr ctx,
-                           cppkafka::TopicPartition                  offset) -> int {
+                    [&offsetManager](Bloomberg::quantum::CoroContext<int>::Ptr ctx,
+                                     cppkafka::TopicPartition                  offset) -> int {
                         // Save the offset
-                        d_offsetManager->saveOffset(offset);
+                        offsetManager.saveOffset(offset);
                         return ctx->set(0);
                     },
                     offset));
@@ -532,112 +471,10 @@ public:
             future->get();
         }
 
-        using namespace std::chrono_literals;
-        
-        while(true)
-        {
-            {
-                quantum::Mutex::Guard guard{ quantum::local::context(), d_offsetsMutex };
-                if (d_lastCommitted)
-                {
-                    EXPECT_EQ(offsets.rbegin()->get_offset(), d_lastCommitted.value().get_offset());
-                    return;
-                }
-            }
-            
-            std::this_thread::sleep_for(1s);
-        }
-    }
-
-private:
-    // Members
-    // Pointers used for deferred initialization
-    std::unique_ptr<Connector>     d_connector;
-    std::unique_ptr<OffsetManager> d_offsetManager;
-    quantum::Mutex                 d_offsetsMutex;
-    cppkafka::TopicPartitionList   d_offsets;
-    std::optional<cppkafka::TopicPartition> d_lastCommitted;
-
-    // Functions
-    void receiveCallback(MessageWithoutHeaders received)
-    {
-        if (received.isEof())
-        {
-            std::cout << "eof" << std::endl;
-            return;
-        }
-        std::cout << "Received a message with offset " << received.getOffset() << std::endl;
-        quantum::Mutex::Guard guard{ quantum::local::context(), d_offsetsMutex };
-        d_offsets.emplace_back(cppkafka::TopicPartition{
-                received.getTopic(), received.getPartition(), received.getOffset() });
-        std::cout << "Now have " << d_offsets.size() << " total received" << std::endl;
-    }
-
-    void offsetCommitCallback(const ConsumerMetadata&             metadata,
-                              cppkafka::Error                     error,
-                              const cppkafka::TopicPartitionList& topicPartitions,
-                              const std::vector<void*>&           opaques)
-    {
-        for (const auto& topicPartition : topicPartitions)
-        {
-            if (topicPartition.get_offset() == RD_KAFKA_OFFSET_INVALID)
-            {
-                continue;
-            }
-            if (!error)
-            {
-                quantum::Mutex::Guard guard{ quantum::local::context(), d_offsetsMutex };
-                d_lastCommitted = topicPartition;
-            }
-        }
-    }
-
-    void logCallback(const Bloomberg::corokafka::Metadata& metadata,
-                     cppkafka::LogLevel                    level,
-                     const std::string&                    facility,
-                     const std::string&                    message)
-    {
-        static std::set<char> evens      = { '0', '2', '4', '6', '8' };
-        auto                  secondToLast = *(message.rbegin() + 1);
-        if ((facility == "OffsetManager:Commit") && (evens.count(secondToLast) == 1u))
-        {
-            auto ctx = Bloomberg::quantum::local::context();
-            if (ctx)
-            {
-                ctx->yield();
-            }
-        }
-    }
-
-    cppkafka::TopicPartitionList extractOffsets(const unsigned int numOffsets)
-    {
-        quantum::Mutex::Guard guard{ quantum::local::context(), d_offsetsMutex };
-        if (d_offsets.size() < numOffsets)
-        {
-            return {};
-        }
-        cppkafka::TopicPartitionList ret;
-        for (unsigned int i = 0; i < numOffsets; ++i)
-        {
-            ret.emplace_back(d_offsets.front());
-            d_offsets.erase(d_offsets.begin());
-        }
-
-        return ret;
-    }
-};    // class OffsetManagerTester
-
-TEST(OffsetManager, SaveOffsetRace)
-{
-    OffsetManagerTester tester;
-
-    unsigned int numTests = 10;
-
-    tester.produce(numTests * 2);
-
-    for (unsigned int i = 0; i < numTests; ++i)
-    {
-        //tester.verifyRaceCondition(2);
+        std::ostringstream stream;
+        stream << "Test #" << i << " Offsets [" << low << ", " << high << "]";
+        SCOPED_TRACE(stream.str());
+        EXPECT_EQ(high, consumerManagerMock.getLastOffset());
     }
 }
 

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -442,7 +442,8 @@ public:
             { ConsumerConfiguration::Options::preprocessMessages, "false" },
             { ConsumerConfiguration::Options::receiveCallbackThreadRangeLow, 1 },
             { ConsumerConfiguration::Options::receiveCallbackThreadRangeHigh, 1 },
-            { ConsumerConfiguration::Options::preserveMessageOrder, true }
+            { ConsumerConfiguration::Options::preserveMessageOrder, true },
+            { ConsumerConfiguration::Options::timeoutMs, "5000" }
         };
         ConsumerConfiguration consumerConfig{
             topicWithoutHeaders(),

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -454,8 +454,9 @@ public:
         consumerConfig.setOffsetCommitCallback(
                 std::bind(&OffsetManagerTester::offsetCommitCallback, this, _1, _2, _3, _4));
         consumerConfig.setLogCallback(std::bind(&OffsetManagerTester::logCallback, this, _1, _2, _3, _4));
-        consumerConfig.assignInitialPartitions(PartitionStrategy::Static,
-                                               { { "", 0, RD_KAFKA_OFFSET_INVALID } });
+        consumerConfig.assignInitialPartitions(
+                PartitionStrategy::Static,
+                { { topicWithoutHeaders().topic(), 0, (int) OffsetPoint::AtEnd } });
 
         builder(consumerConfig);
         // Producer configuration
@@ -611,7 +612,7 @@ private:
             return {};
         }
         cppkafka::TopicPartitionList ret;
-        for (int i = 0; i < numOffsets; ++i)
+        for (unsigned int i = 0; i < numOffsets; ++i)
         {
             ret.emplace_back(d_offsets.front());
             d_offsets.erase(d_offsets.begin());

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -401,13 +401,14 @@ public:
                                   Configuration::OptionList topicOptions)
         : mocks::ConsumerManagerMock{ topic, options, topicOptions }
     {}
+
     // Fake commit() - trust that topicPartitions is always size=1 for these tests
-    cppkafka::Error commit(const cppkafka::TopicPartitionList& topicPartitions,
-                           const void*                         opaque) override
+    cppkafka::Error commit(const cppkafka::TopicPartition& topicPartition,
+                           const void*                     opaque) override
     {
         auto ctx = quantum::local::context();
         // yield if offset is even - to increase the odds of the race condition
-        if (topicPartitions[0].get_offset() % 2 == 0)
+        if (topicPartition.get_offset() % 2 == 0)
         {
             if (ctx)
             {
@@ -416,15 +417,15 @@ public:
         }
 
         quantum::Mutex::Guard guard{ ctx, d_mutex };
-        std::cout << "Going to record commit() " << topicPartitions[0] << std::endl;
-        d_committed = topicPartitions[0];
+        std::cout << "Going to record commit() " << topicPartition << std::endl;
+        d_committed = topicPartition;
 
         return {};
     }
 
-    cppkafka::Error commit(const cppkafka::TopicPartitionList& topicPartitions,
-                           ExecMode                            execMode,
-                           const void*                         opaque) override
+    cppkafka::Error commit(const cppkafka::TopicPartition& topicPartition,
+                           ExecMode                        execMode,
+                           const void*                     opaque) override
     {
         std::cout << "commit() with ExecMode called" << std::endl;
         return {};

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -442,9 +442,13 @@ TEST(OffsetManager, SaveOffsetRace)
                                                                 Configuration::OptionList{});
     // Expectations
     auto& metadataMock = consumerManagerMock.consumerMetadataMock();
-    const cppkafka::TopicPartitionList committedOffsets{ {  TopicName, 0, -1  } };
-    EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(committedOffsets));
-    EXPECT_CALL(metadataMock, queryOffsetWatermarks()).WillOnce(Return(Watermarks));
+    const OffsetWatermarkList watermarks{
+        { Partition,
+          { cppkafka::TopicPartition::Offset::OFFSET_INVALID,
+            cppkafka::TopicPartition::Offset::OFFSET_INVALID } }
+    };
+    EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(CommittedInvalid));
+    EXPECT_CALL(metadataMock, queryOffsetWatermarks()).WillOnce(Return(watermarks));
     EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(StoredAssignment));
 
     OffsetManagerTestAdapter offsetManager(consumerManagerMock);

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -417,7 +417,6 @@ public:
         }
 
         quantum::Mutex::Guard guard{ ctx, d_mutex };
-        std::cout << "Going to record commit() " << topicPartition << std::endl;
         d_committed = topicPartition;
 
         return {};
@@ -449,7 +448,7 @@ TEST(OffsetManager, SaveOffsetRace)
 
     OffsetManagerTestAdapter offsetManager(consumerManagerMock);
 
-    unsigned int numTests = 100;
+    unsigned int numTests = 1000;
 
     for (unsigned int i = 0; i < numTests; ++i)
     {

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -449,9 +449,11 @@ TEST(OffsetManager, SaveOffsetRace)
     };
     EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(CommittedInvalid));
     EXPECT_CALL(metadataMock, queryOffsetWatermarks()).WillOnce(Return(watermarks));
-    EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(StoredAssignment));
+    EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(BeginningAssignment));
 
     OffsetManagerTestAdapter offsetManager(consumerManagerMock);
+    offsetManager.resetPartitionOffsets(TopicName,
+                                        OffsetManagerImpl::ResetAction::DoNotFetchOffsets);
 
     unsigned int numTests = 10;
 

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -449,7 +449,7 @@ TEST(OffsetManager, SaveOffsetRace)
 
     OffsetManagerTestAdapter offsetManager(consumerManagerMock);
 
-    unsigned int numTests = 10;
+    unsigned int numTests = 100;
 
     for (unsigned int i = 0; i < numTests; ++i)
     {


### PR DESCRIPTION
Signed-off-by: Adam M. Rosenzweig <arosenzweig3@bloomberg.net>

**NOT READY FOR APPROVAL**

**Describe your changes**
A clear and concise description of the changes you have made.

This change contains only a new test, whose purpose is to demonstrate a race condition we discovered in `corokafka::OffsetManager`. The race is that, sometimes, due to thread scheduling, when you `saveOffset` on offsets 0 & 1, despite `OffsetManager` not trying to commit offset 1 until it has tried offset 0, you may see a situation where offset 0 is inserted and then committed by `OffsetManager`, and then offset 1 is, but the actual commit call on offset 1 completes before the commit call on offset 0. This can result in reporting the wrong offset to the kafka broker.

Here's an example execution flow in pseudo-code:
Thread A: `OffsetManager.saveOffset(0)`
Thread A: log OffsetManager:Insert (0)
Thread A: log OffsetManager:Commit (0)
Thread A execution paused due to scheduling
Thread B: `OffsetManager.saveOffset(1)`
Thread B: log OffsetManager:Insert (1)
Thread B: log OffsetManager:Commit (1)
Thread B: `_consumerManager.commit(1)`
Thread A resumes
Thread A: `_consumerManager.commit(0)`

In this case, the broker may see only offset 0 committed, and never see offset 1 committed. This can cause alarms, as well potentially receiving the message at offset 1 a second time. (Once offset 2 is committed, the problem is suppressed.)

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

This commit contains only a test designed to replicate the bug with increased reliability. A subsequent commit will contain a fix.

**Additional context**
Add any other context about your contribution here.
