### PR TITLE
Demonstrate race condition in OffsetManager::saveOffset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
   - sudo sysctl -w kernel.core_pattern=$TRAVIS_BUILD_DIR/cores/core.%e.%p
   - cat /proc/sys/kernel/core_pattern
   - service --status-all || true
-  - KAFKA_REL=2.6.1  
+  - KAFKA_REL=2.8.1  
   - KAFKA_VERSION=2.12-$KAFKA_REL
   - RD_KAFKA_VERSION=v1.6.0
   - wget http://apache.cs.utah.edu/kafka/$KAFKA_REL/kafka_$KAFKA_VERSION.tgz && tar -xvzf kafka_$KAFKA_VERSION.tgz

--- a/corokafka/impl/corokafka_offset_manager_impl.h
+++ b/corokafka/impl/corokafka_offset_manager_impl.h
@@ -188,7 +188,6 @@ cppkafka::Error OffsetManagerImpl::forceCommitImpl(EXEC_MODE&&...execMode)
     try {
         bool isSyncCommit = false;
         for (auto& topic : _topicMap) {
-            cppkafka::TopicPartitionList partitions;
             TopicSettings& settings = topic.second;
             for (auto& partition : settings._partitions) {
                 Range<int64_t> range(-1,-1);
@@ -204,17 +203,14 @@ cppkafka::Error OffsetManagerImpl::forceCommitImpl(EXEC_MODE&&...execMode)
                 }
                 //Commit range
                 if (range.second != -1) {
-                    partitions.emplace_back(topic.first, partition.first, range.second);
+                    cppkafka::TopicPartition toCommit{ topic.first, partition.first, range.second };
+                    logOffsets("OffsetManager:Commit", toCommit);
+                    cppkafka::Error error = _consumerManager.commit(toCommit, std::forward<EXEC_MODE>(execMode)...);
+                    if (error) {
+                        return error;
+                    }
                 }
             } //partitions
-            //Commit all offsets for this topic
-            if (!partitions.empty()) {
-                logOffsets("OffsetManager:Commit", partitions);
-                cppkafka::Error error = _consumerManager.commit(partitions, std::forward<EXEC_MODE>(execMode)...);
-                if (error) {
-                    return error;
-                }
-            }
         } //topics
         return {};
     }
@@ -230,16 +226,14 @@ cppkafka::Error OffsetManagerImpl::forceCommitPartitionImpl(const cppkafka::Topi
     try {
         Range<int64_t> range(-1,-1);
         OffsetRanges& ranges = getOffsetRanges(getTopicSettings(partition), partition);
-        { //locked scope
-            quantum::Mutex::Guard guard(quantum::local::context(), ranges._offsetsMutex);
-            Iterator it = ranges._offsets.begin();
-            if (it != ranges._offsets.end()) {
-                range = *it;
-                //bump current offset
-                ranges._currentOffset = range.second;
-                //delete range from map
-                ranges._offsets.erase(it);
-            }
+        quantum::Mutex::Guard guard(quantum::local::context(), ranges._offsetsMutex);
+        Iterator it = ranges._offsets.begin();
+        if (it != ranges._offsets.end()) {
+            range = *it;
+            //bump current offset
+            ranges._currentOffset = range.second;
+            //delete range from map
+            ranges._offsets.erase(it);
         }
         //Commit range
         if (range.second != -1) {
@@ -263,31 +257,25 @@ cppkafka::Error OffsetManagerImpl::forceCommitCurrentOffsetImpl(EXEC_MODE&&...ex
     try {
         bool isSyncCommit = false;
         for (auto& topic : _topicMap) {
-            cppkafka::TopicPartitionList partitions;
             TopicSettings& settings = topic.second;
             for (auto& partition : settings._partitions) {
                 OffsetRanges& ranges = partition.second;
                 Range<int64_t> range(-1,-1);
-                {//locked scope
-                    if (_traceCommits) {
-                        logOffsets("OffsetManager:Insert", {topic.first, partition.first, ranges._currentOffset + 1});
-                    }
-                    quantum::Mutex::Guard guard(quantum::local::context(), ranges._offsetsMutex);
-                    range = insertOffset(ranges, ranges._currentOffset + 1);
+                if (_traceCommits) {
+                    logOffsets("OffsetManager:Insert", {topic.first, partition.first, ranges._currentOffset + 1});
                 }
+                quantum::Mutex::Guard guard(quantum::local::context(), ranges._offsetsMutex);
+                range = insertOffset(ranges, ranges._currentOffset + 1);
                 //Commit range
                 if (range.second != -1) {
-                    partitions.emplace_back(topic.first, partition.first, range.second);
+                    cppkafka::TopicPartition toCommit{ topic.first, partition.first, range.second };
+                    logOffsets("OffsetManager:Commit", toCommit);
+                    cppkafka::Error error = _consumerManager.commit(toCommit, std::forward<EXEC_MODE>(execMode)...);
+                    if (error) {
+                        return error;
+                    }
                 }
             } //partitions
-            //Commit all offsets for this topic
-            if (!partitions.empty()) {
-                logOffsets("OffsetManager:Commit", partitions);
-                cppkafka::Error error = _consumerManager.commit(partitions, std::forward<EXEC_MODE>(execMode)...);
-                if (error) {
-                    return error;
-                }
-            }
         } //topics
         return {};
     }

--- a/corokafka/impl/corokafka_offset_manager_impl.h
+++ b/corokafka/impl/corokafka_offset_manager_impl.h
@@ -162,11 +162,9 @@ cppkafka::Error OffsetManagerImpl::saveOffsetImpl(const cppkafka::TopicPartition
         }
         OffsetRanges& ranges = getOffsetRanges(getTopicSettings(offset), offset);
         Range<int64_t> range(-1,-1);
-        {//locked scope
-            logOffsets("OffsetManager:Insert", offset);
-            quantum::Mutex::Guard guard(quantum::local::context(), ranges._offsetsMutex);
-            range = insertOffset(ranges, offset.get_offset());
-        }
+        logOffsets("OffsetManager:Insert", offset);
+        quantum::Mutex::Guard guard(quantum::local::context(), ranges._offsetsMutex);
+        range = insertOffset(ranges, offset.get_offset());
         //Commit range
         if (range.second != -1) {
             //This is a valid range

--- a/corokafka/utils/corokafka_offset_manager.h
+++ b/corokafka/utils/corokafka_offset_manager.h
@@ -63,6 +63,8 @@ public:
     /// @remark The offset specified indicates the 'next position to be read from'. It should typically be the last
     ///         message offset incremented by 1. This function will *not* perform any increments.
     /// @remark Offset must be > getCurrentOffset(). Committing a smaller offset has no effect.
+    /// @remark Synchronous commits may incur performance penalties if multiple coroutines or threads are processing messages
+    ///         for the same partition.
     cppkafka::Error saveOffset(const cppkafka::TopicPartition& offset) override;
     cppkafka::Error saveOffset(const cppkafka::TopicPartition& offset,
                                ExecMode execMode) override;
@@ -73,6 +75,8 @@ public:
     /// @returns Error.
     /// @remark This function *will* perform the offset increment automatically and will commit IMessage::getOffset()+1.
     /// @remark Message offset must be >= getCurrentOffset(). Committing a smaller offset has no effect.
+    /// @remark Synchronous commits may incur performance penalties if multiple coroutines or threads are processing messages
+    ///         for the same partition.
     cppkafka::Error saveOffset(const IMessage& message) override;
     cppkafka::Error saveOffset(const IMessage& message,
                                ExecMode execMode) override;

--- a/tests/corokafka_tests_3_consumer.cpp
+++ b/tests/corokafka_tests_3_consumer.cpp
@@ -6,7 +6,7 @@ namespace Bloomberg {
 namespace corokafka {
 namespace tests {
 
-const int MaxLoops = 30; //arbitrary wait value
+const int MaxLoops = 60; //arbitrary wait value
 const int NumPartitions = 4;
 
 void waitUntilEof()

--- a/tests/corokafka_tests_4_dispatcher.cpp
+++ b/tests/corokafka_tests_4_dispatcher.cpp
@@ -1,15 +1,20 @@
 #include <corokafka_tests_callbacks.h>
 #include <gtest/gtest.h>
 
-namespace Bloomberg {
-namespace corokafka {
-namespace tests {
-
-TEST(Quantum, Drain)
+namespace Bloomberg::corokafka::tests
 {
-    //This test must run last
-    dispatcher().drain();
-    dispatcher().terminate();
-}
 
-}}}
+class QuantumEnvironment : public ::testing::Environment
+{
+    public:
+        ~QuantumEnvironment() override{};
+
+        void TearDown() override { dispatcher().drain();
+            dispatcher().terminate();
+        }
+};  // class QuantumEnvironment
+
+::testing::Environment* const quantumEnvironment =
+        testing::AddGlobalTestEnvironment(new QuantumEnvironment);
+
+}    // namespace Bloomberg::corokafka::tests

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -159,8 +159,7 @@ TEST(OffsetManager, CommitAllCurrentOffsets)
     
     auto current = offsetManager.getCurrentOffset(QueryPartition);
     cppkafka::TopicPartition nextCurrent = current + 1;
-    cppkafka::TopicPartitionList currentList = {nextCurrent};
-    EXPECT_CALL(consumerManagerMock, commit(currentList, nullptr)).Times(1);
+    EXPECT_CALL(consumerManagerMock, commit(nextCurrent, nullptr)).Times(1);
     offsetManager.forceCommitCurrentOffset();
     
     //Make sure the current offset has also been changed but not the beginning offset

--- a/tests/corokafka_tests_offset_manager.cpp
+++ b/tests/corokafka_tests_offset_manager.cpp
@@ -1,6 +1,10 @@
 #include <corokafka/impl/corokafka_offset_manager_impl.h>
 #include <corokafka/mock/corokafka_consumer_manager_mock.h>
 
+#include <corokafka_tests_utils.h>
+
+#include <quantum/quantum_mutex.h>
+
 using testing::_;
 using testing::Return;
 using testing::ReturnRef;
@@ -11,9 +15,8 @@ using testing::IsFalse;
 using testing::Matcher;
 using testing::NiceMock;
 
-namespace Bloomberg {
-namespace corokafka {
-namespace tests {
+namespace Bloomberg::corokafka::tests
+{
 
 const std::string TopicName = "MockTopic";
 const int Partition = 0;
@@ -389,5 +392,94 @@ TEST(OffsetManager, ResetPartitionNoFetch)
     EXPECT_THROW(offsetManager.getCurrentOffset(QueryPartition), std::out_of_range);
 }
 
-}}}
+class ConsumerManagerOffsetRaceFake : public mocks::ConsumerManagerMock
+{
+public:
+    template<typename TOPIC>
+    ConsumerManagerOffsetRaceFake(const TOPIC&              topic,
+                                  Configuration::OptionList options,
+                                  Configuration::OptionList topicOptions)
+        : mocks::ConsumerManagerMock{ topic, options, topicOptions }
+    {}
+
+    // Fake commit() - trust that topicPartitions is always size=1 for these tests
+    cppkafka::Error commit(const cppkafka::TopicPartition& topicPartition,
+                           const void*                     opaque) override
+    {
+        using namespace std::chrono_literals;
+        auto ctx = quantum::local::context();
+        // yield if offset is even - to increase the odds of the race condition
+        if (topicPartition.get_offset() % 2 == 0)
+        {
+            if (ctx)
+            {
+                ctx->sleep(10ms);
+            }
+        }
+
+        quantum::Mutex::Guard guard{ ctx, d_mutex };
+        d_committed = topicPartition;
+
+        return {};
+    }
+
+    int64_t getLastOffset()
+    {
+        quantum::Mutex::Guard guard{ quantum::local::context(), d_mutex };
+        return d_committed.get_offset();
+    }
+
+private:
+    quantum::Mutex           d_mutex;
+    cppkafka::TopicPartition d_committed;
+
+};    // ConsumerManagerOffsetRaceFake
+
+TEST(OffsetManager, SaveOffsetRace)
+{
+    NiceMock<ConsumerManagerOffsetRaceFake> consumerManagerMock(mocks::MockTopic{ TopicName },
+                                                                Configuration::OptionList{},
+                                                                Configuration::OptionList{});
+    // Expectations
+    auto& metadataMock = consumerManagerMock.consumerMetadataMock();
+    const OffsetWatermarkList watermarks{ { Partition, { -1, -1 } } };
+    EXPECT_CALL(metadataMock, queryCommittedOffsets()).WillOnce(Return(CommittedInvalid));
+    EXPECT_CALL(metadataMock, queryOffsetWatermarks()).WillOnce(Return(watermarks));
+    EXPECT_CALL(metadataMock, getPartitionAssignment()).WillOnce(ReturnRef(BeginningAssignment));
+
+    OffsetManagerTestAdapter offsetManager(consumerManagerMock);
+
+    unsigned int numTests = 1000;
+
+    for (unsigned int i = 0; i < numTests; ++i)
+    {
+        unsigned int                 low  = i * 2;
+        unsigned int                 high = low + 1;
+        cppkafka::TopicPartitionList offsets{ { TopicName, 0, low }, { TopicName, 0, high } };
+        std::vector<Bloomberg::quantum::ThreadContext<int>::Ptr> futures;
+        for (const auto& offset : offsets)
+        {
+            futures.emplace_back(dispatcher().post2(
+                    [&offsetManager](Bloomberg::quantum::CoroContext<int>::Ptr ctx,
+                                     cppkafka::TopicPartition                  offset) -> int {
+                        // Save the offset
+                        offsetManager.saveOffset(offset);
+                        return ctx->set(0);
+                    },
+                    offset));
+        }
+
+        for (auto& future : futures)
+        {
+            future->get();
+        }
+
+        std::ostringstream stream;
+        stream << "Test #" << i << " Offsets [" << low << ", " << high << "]";
+        SCOPED_TRACE(stream.str());
+        EXPECT_EQ(high, consumerManagerMock.getLastOffset());
+    }
+}
+
+}   // namespace Bloomberg::corokafka::tests
 


### PR DESCRIPTION
Signed-off-by: Adam M. Rosenzweig <arosenzweig3@bloomberg.net>

**Describe your changes**
A clear and concise description of the changes you have made.

`OffsetManager::saveOffset` has a race condition when used in multiple threads. Because only part of the function is treated as a critical section, it is possible for two threads to both save their respective offsets, but for one to step on the other. Consider the following scenario:

Thread A: call `OffsetManager.saveOffset(0)`
Thread A: log OffsetManager:Insert (0)
Thread A: log OffsetManager:Commit (0)
Thread A execution paused due to scheduling
Thread B: call `OffsetManager.saveOffset(1)`
Thread B: log OffsetManager:Insert (1)
Thread B: log OffsetManager:Commit (1)
Thread B: calls `_consumerManager.commit(1)`
Thread A resumes
Thread A: calls `_consumerManager.commit(0)`

In this case, the broker may see only offset 0 committed, and never see offset 1 committed. This can cause alarms, as well potentially receiving the message at offset 1 a second time. (Once offset 2 is committed, the problem is suppressed.)

Fix this by extending the critical section to include the call to `_consumerManager.commit()`.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

A new unit test has been added that reproduces the race condition by consciously yielding on the offset 0 `_consumerManager.commit()` calls and not the offset 1 calls. This raises the likelihood of a race conditioning happening substantially. 

**Additional context**
Add any other context about your contribution here.
