### PR TITLE
Skip empty headers when serializing messages.

### DIFF
--- a/corokafka/corokafka_configuration.cpp
+++ b/corokafka/corokafka_configuration.cpp
@@ -232,7 +232,7 @@ void Configuration::parseOptions(const std::string& topic,
             }
             trim(const_cast<std::string&>(option.get_value()));
             if (option.get_value().empty()) {
-                throw InvalidOptionException(topic, option.get_value(), "Value is empty");
+                throw InvalidOptionException(topic, option.get_key(), "Value is empty");
             }
             const auto it = allowed.find(option.get_key());
             if (it == allowed.end()) {

--- a/corokafka/impl/corokafka_producer_manager_impl.h
+++ b/corokafka/impl/corokafka_producer_manager_impl.h
@@ -219,10 +219,9 @@ bool serializeHeaders(const TOPIC&, size_t, ProducerMessageBuilder<ByteArray>&)
 template <typename TOPIC, typename H, typename ... Hs>
 bool serializeHeaders(const TOPIC& topic, size_t i, ProducerMessageBuilder<ByteArray>& builder, const H& h, const Hs&...hs) {
     ByteArray b = Serialize<H>{}(h);
-    if (b.empty()) {
-        return false;
+    if (!b.empty()) {
+        builder.header(cppkafka::Header<ByteArray>{topic.headers().names()[i], std::move(b)});
     }
-    builder.header(cppkafka::Header<ByteArray>{topic.headers().names()[i], std::move(b)});
     //Serialize next header in the list
     return serializeHeaders(topic, ++i, builder, hs...);
 }

--- a/corokafka/impl/corokafka_received_message_impl.h
+++ b/corokafka/impl/corokafka_received_message_impl.h
@@ -16,6 +16,7 @@
 #ifndef BLOOMBERG_COROKAFKA_RECEIVED_MESSAGE_IMPL_H
 #define BLOOMBERG_COROKAFKA_RECEIVED_MESSAGE_IMPL_H
 
+#include <corokafka/corokafka_deserializer.h>
 #include <corokafka/corokafka_exception.h>
 #include <corokafka/interface/corokafka_ireceived_message.h>
 

--- a/tests/corokafka_tests_2_producer.cpp
+++ b/tests/corokafka_tests_2_producer.cpp
@@ -402,7 +402,17 @@ TEST(Producer, ValidateErrorCallback)
     counters.reset();
 }
 
+TEST(Producer, serializeHeaders)
+{
+    ProducerMessageBuilder<ByteArray> builder;
 
+    // One populated string, one empty string, one explicit null header
+    std::string header1{ "header-value" };
+    std::string header2{ "" };
+
+    EXPECT_TRUE(serializeHeaders(serializeOnlyTopic(), 0, builder, header1, header2, NullHeader{}));
+    EXPECT_EQ(1u, builder.header_list().size());
+}
 }
 }
 }

--- a/tests/corokafka_tests_topics.h
+++ b/tests/corokafka_tests_topics.h
@@ -44,9 +44,11 @@ struct Message {
 using TestHeaders = Headers<Header1, Header2>;
 using TopicWithHeaders = Topic<Key, Message, TestHeaders>;
 using TopicWithoutHeaders = Topic<Key, Message>;
+using SerializeOnlyTopic = Topic<Key, Message, Headers<std::string, std::string, std::string>>;
 
 static constexpr const char* header1Str = "Header-1";
 static constexpr const char* header2Str = "Header-2";
+static constexpr const char* header3Str = "Header-3";
 
 // Create a topic which will be shared between producer and consumer.
 inline
@@ -57,6 +59,15 @@ const TopicWithHeaders& topicWithHeaders() {
 inline
 const TopicWithoutHeaders& topicWithoutHeaders() {
     static TopicWithoutHeaders topic(programOptions()._topicWithoutHeaders);
+    return topic;
+}
+
+inline
+const SerializeOnlyTopic& serializeOnlyTopic() {
+    static SerializeOnlyTopic topic{ "serialize-only",
+                               Header<std::string>{ header1Str },
+                               Header<std::string>{ header2Str },
+                               Header<std::string>{ header3Str } };
     return topic;
 }
 
@@ -119,6 +130,12 @@ struct Serialize<tests::Message>
         ret.insert(ret.end(), payload._message.begin(), payload._message.end());
         return ret;
     }
+};
+
+template<>
+struct Serialize<std::string>
+{
+    ByteArray operator()(const std::string& in) { return { in.cbegin(), in.cend() }; }
 };
 
 //======================================================================================================================


### PR DESCRIPTION
Signed-off-by: Adam M. Rosenzweig <arosenzweig3@bloomberg.net>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

As a convenience to users, if serializing a header creates an empty buffer, rather than failing to produce the message, simply skip that header. This should reduce the need to have application logic have many potential `send()` or `post()` calls if they have optional headers.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
